### PR TITLE
GitHub Actionsに自動テストを追加

### DIFF
--- a/.github/workflows/autio-test.yml
+++ b/.github/workflows/autio-test.yml
@@ -48,6 +48,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
              ${{ runner.os }}-go-
+          # キャッシュ復元失敗でも workflow 続行
+          fail-on-cache-miss: false 
 
       - name: Verify dependencies
         run: go mod tidy && git diff --exit-code go.mod go.sum 
@@ -62,6 +64,7 @@ jobs:
         with:
           name: coverage-report
           path: coverage/coverage.out
+          if-no-files-found: ignore  # coverage.out が存在しなくても警告抑制
     
       # テスト失敗時はコンテナログを取得する
       - name: Save container logs if failed

--- a/.github/workflows/autio-test.yml
+++ b/.github/workflows/autio-test.yml
@@ -4,6 +4,9 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]  
+  # 毎日午前3：00に実行する(JST 03:00 = UTC 18:00)
+  schedule:
+    - cron: "0 18 * * *"
 
 jobs:
   lint:

--- a/.github/workflows/autio-test.yml
+++ b/.github/workflows/autio-test.yml
@@ -6,6 +6,25 @@ on:
     branches: [main, develop]  
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with: 
+          go-version: 1.24
+
+      # Go言語のコードを分析
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/autio-test.yml
+++ b/.github/workflows/autio-test.yml
@@ -55,6 +55,13 @@ jobs:
       # Docker Composeでビルドとテスト実行
       - name: Build and run tests (docker-compose)
         run: docker compose -f docker-compose.test.yml up --build --abort-on-container-exit || exit 1
+
+      # カバレッジ対応
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/coverage.out
     
       # テスト失敗時はコンテナログを取得する
       - name: Save container logs if failed

--- a/.github/workflows/autio-test.yml
+++ b/.github/workflows/autio-test.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           name: test-logs
           path: logs/test.log
+          if-no-files-found: ignore
 
       - name: Cleanup
         run:  docker compose -f docker-compose.test.yml down -v

--- a/.github/workflows/autio-test.yml
+++ b/.github/workflows/autio-test.yml
@@ -1,4 +1,4 @@
-name: Go CI with PostgreSQL
+name: CI Auto Test 
 on:
   push:
     branches: [main, develop]
@@ -11,10 +11,27 @@ jobs:
 
     steps:
       # ランナー環境にリポジトリのコードをチェックアウトする
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set Up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+             ${{ runner.os }}-go-
+
+      - name: Verify dependencies
+        run: go mod tidy && git diff --exit-code go.mod go.sum 
 
       # Docker Composeでビルドとテスト実行
-      - name: Build and run tests
+      - name: Build and run tests (docker-compose)
         run: docker compose -f docker-compose.test.yml up --build --abort-on-container-exit || exit 1
     
       # テスト失敗時はコンテナログを取得する

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: Go CI with PostgreSQL
+on:
   push:
     branches: [main, develop]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,41 +8,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    services:
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_USER: testuser
-          POSTGRES_PASSWORD: testpass
-          POSTGRES_DB: testdb
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U testuser"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       # ランナー環境にリポジトリのコードをチェックアウトする
       - uses: actions/checkout@v3
 
-      - name: Set up Go
-      #actions/setup-go アクションのバージョン 4 を利用
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21
-      
-      - name: Install dependencies
-        run: go mod tidy
-
-      - name: Wait for Postgres
+      # Docker Composeでビルドとテスト実行
+      - name: Build and run tests
         run: |
-          until pg_isready -h localhost -p 5432 -U testuser; do
-            sleep 1
-          done
+          docker-compose -f docker-compose.test.yml up --build --abort-on-container-exit || exit 1
+    
+      # コンテナログを取得する
+      - name: Save container logs if failed
+        if: failure()
+        run: |
+          mkdir -p logs
+          docker-compose -f docker-compose.test.yml logs > logs/test.log || true
+          cat logs/test.log
 
-      - name: Run test
-        env:
-          DATABASE_URL: postgres://testuser:testpass@localhost:5432/testdb?sslmode=disable
-        run: go test -v ./...
+      - name: Cleanup
+        run:  docker-compose -f docker-compose.test.yml down -v
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Go CI with PostgreSQL
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]  
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U testuser"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      # ランナー環境にリポジトリのコードをチェックアウトする
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+      #actions/setup-go アクションのバージョン 4 を利用
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      
+      - name: Install dependencies
+        run: go mod tidy
+
+      - name: Wait for Postgres
+        run: |
+          until pg_isready -h localhost -p 5432 -U testuser; do
+            sleep 1
+          done
+
+      - name: Run test
+        env:
+          DATABASE_URL: postgres://testuser:testpass@localhost:5432/testdb?sslmode=disable
+        run: go test -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,16 @@ jobs:
       # Docker Composeでビルドとテスト実行
       - name: Build and run tests
         run: |
-          docker-compose -f docker-compose.test.yml up --build --abort-on-container-exit || exit 1
+          docker compose -f docker-compose.test.yml up --build --abort-on-container-exit || exit 1
     
       # コンテナログを取得する
       - name: Save container logs if failed
         if: failure()
         run: |
           mkdir -p logs
-          docker-compose -f docker-compose.test.yml logs > logs/test.log || true
+          docker compose -f docker-compose.test.yml logs > logs/test.log || true
           cat logs/test.log
 
       - name: Cleanup
-        run:  docker-compose -f docker-compose.test.yml down -v
+        run:  docker compose -f docker-compose.test.yml down -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,23 @@ jobs:
 
       # Docker Composeでビルドとテスト実行
       - name: Build and run tests
-        run: |
-          docker compose -f docker-compose.test.yml up --build --abort-on-container-exit || exit 1
+        run: docker compose -f docker-compose.test.yml up --build --abort-on-container-exit || exit 1
     
-      # コンテナログを取得する
+      # テスト失敗時はコンテナログを取得する
       - name: Save container logs if failed
         if: failure()
         run: |
           mkdir -p logs
           docker compose -f docker-compose.test.yml logs > logs/test.log || true
           cat logs/test.log
+
+      # テスト失敗時はログをartifactにUP
+      - name: Upload test logs
+        if: always()
+        uses: actions/Upload-artifact@v4
+        with:
+          name: test-logs
+          path: logs/test.log
 
       - name: Cleanup
         run:  docker compose -f docker-compose.test.yml down -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,33 @@
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  enable:
+    - govet           # Go公式の静的解析
+    - errcheck        # エラーハンドリングの漏れを検出
+    - staticcheck     # Goのベストプラクティスに基づく解析
+    - unused          # 使われてない変数や関数を検出
+    - gosimple        # 冗長なコードをシンプルに
+    - gocritic        # より高度なコード改善提案
+    - gofmt           # フォーマットチェック
+    - goimports       # import整列もチェック 
+
+  disable:
+    - depguard        # 特定のパッケージ利用禁止
+
+issues:
+  exclude-rules:
+    - linters:
+        - errcheck
+      text: "Close"   # defer file.Closeのエラーチェックを無視する
+
+  max-same-issues: 3
+  max-issues-per-linter: 10
+  exclude-use-default: false
+
+output:
+  formats:
+    - format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Go Blog API
 
-Go言語とPostgreSQLを使ったブログAPIのポートフォリオです。投稿とコメント、いいねのCRUD機能を備え、JWTによる認証・認可も実装しています。
+Go言語とPostgreSQLを使ったブログAPIのポートフォリオです。  
+投稿とコメント、いいねのCRUD機能を備え、JWTによる認証・認可も実装しています。  
+開発・テスト環境はDocker Composeで統一し、GitHub ActionsによるCI/CDを構築しています。
 
 ---
 
 ## 使用技術
 
-- Go (net/http, encoding/json, sql)
-- PostgreSQL
-- JWT 認証（github.com/golang-jwt/jwt）
-- Docker（開発用PostgreSQL）
-- `testing` パッケージによるユニットテスト
+- 言語: Go (net/http, encoding/json, sql)
+- データベース: PostgreSQL
+- 認証: JWT（github.com/golang-jwt/jwt）
+- コンテナ: Docker, docker-compose
+- CI/CD: GitHub Actions
+- テスト: GO `testing` パッケージ
 
 ---
 
@@ -20,8 +23,9 @@ Go言語とPostgreSQLを使ったブログAPIのポートフォリオです。�
 
 - Go: 1.24.2
 - PostgreSQL: 15.13
-- OS: Ubuntu 22.04
+- OS: Ubuntu 22.04（推奨）
 - Docker:27.5.1
+- docker compose V2
 
 ### クローンと初期化
 
@@ -44,18 +48,54 @@ DB_TEST_PORT=5433
 DB_HOST=db
 JWT_SECRET=your_jwt_secret
 APP_PORT=8080
+
+# DB接続用URL（Goのアプリで利用）
+DATABASE_URL=postgres://postgres:yourpassword@db:5432/blog?sslmode=disable
 ```
 
 ---
 
-## 実行方法
+## 実行方法(ローカル)
 
 ```bash
-go run main.go
+docker compose up --build
 ```
 
-http://localhost:8080 にてAPIサーバーが起動します。
+http://localhost:8080 にてAPIサーバーが起動します。  
+pgAdmin も利用可能です。（http://localhost:5050）
 
+
+---
+
+## テスト実行方法(Docker環境)
+
+毎回クリーンなDBでテストをするため、`down -v` を利用します。
+
+```bash
+# DBを初期化してテスト実行
+docker compose -f docker-compose.test.yml up --build --abort-on-container-exit
+
+# テスト後にコンテナ削除
+docker compose -f docker-compose.test.yml down -v
+```
+---
+
+## ログ確認方法
+
+```bash
+# DBログ
+docker compose -f docker-compose.test.yml logs db
+
+# アプリケーションログ
+docker compose -f docker-compose.test.yml logs goapp
+```
+
+---
+
+## CI/CD
+
+GitHub Actionsにて `docker-compose.test.yml` を利用し、PR作成時やmainブランチ、developブランチにpush時に自動テストを実行。  
+ローカルと同一の環境でテストすることで、再現性の高いCIを実現しています。
 
 ---
 
@@ -65,22 +105,13 @@ http://localhost:8080 にてAPIサーバーが起動します。
 
 ---
 
-## テスト実行方法
-
-```bash
-go test ./... -v
-```
-
-テストは実装したハンドラー関数に対して正常系と異常系のテストを実施しています。※未対応のものは随時追加中
-
----
-
 ## 今後の改善予定
 
 - フロントエンド実装（React/Vueなど）
 - Swagger/OpenAPIドキュメント生成
 - ソーシャル認証連携（Googleなど）
 - タグ機能
+- CI/CDの本番デプロイ自動化
 
 ---
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   db:
     image: postgres:15

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -18,9 +18,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: go_test
     depends_on:
       db:
         condition: service_healthy
     environment:
       DATABASE_URL: postgres://postgres:yourpassword@db:5432/blog_test?sslmode=disable
-    command: ["go", "test", "-v", "./..."]
+    command: >
+      sh -c "go test ./... -v -coverprofile=coverage/coverage.out -covermode=atomic"
+    volumes:
+      - ./coverage:/app/coverage
+

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,28 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:15
+    container_name: postgres_test
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_TEST_NAME}
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://postgres:yourpassword@db:5432/blog_test?sslmode=disable
+    command: ["go", "test", "-v", "./..."]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -25,7 +25,7 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:yourpassword@db:5432/blog_test?sslmode=disable
     command: >
-      sh -c "go test ./... -v -coverprofile=coverage/coverage.out -covermode=atomic"
+      sh -c "rm -f coverage/coverage.out && go test ./... -v -coverprofile=coverage/coverage.out -covermode=atomic"
     volumes:
       - ./coverage:/app/coverage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   app:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.9'
 services:
   app:
     build: .

--- a/handler/comments.go
+++ b/handler/comments.go
@@ -197,8 +197,10 @@ func DeleteCommentHandler(db *sql.DB) http.HandlerFunc {
 
 		// リクエスト正常終了
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "Comment deleted successfully!")
-
+		if _, err := fmt.Fprintln(w, "Comment deleted successfully!"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -264,7 +266,9 @@ func UpdateCommentHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "Comment update successfully!")
-
+		if _, err := fmt.Fprintln(w, "Comment update successfully!"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }

--- a/handler/comments.go
+++ b/handler/comments.go
@@ -59,8 +59,10 @@ func GetCommentsByPostIDHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(comments)
-
+		if err := json.NewEncoder(w).Encode(comments); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -89,8 +91,10 @@ func GetCommentsByIDHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(comment)
-
+		if err := json.NewEncoder(w).Encode(comment); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -140,7 +144,10 @@ func PostCommentHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(map[string]string{"message": "Comment created"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"message": "Comment created"}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
 	}
 }

--- a/handler/comments_test.go
+++ b/handler/comments_test.go
@@ -16,22 +16,22 @@ import (
 
 // コメント投稿用APIのテスト
 func TestPostCommentHandle(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用サーバーのセットアップ
+	// テスト用サーバーのセットアップ
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//テスト用のJWTトークン発行
+	// テスト用のJWTトークン発行
 	token, err := handler.GenerateJWT(3)
 	if err != nil {
 		t.Fatal("JWTの生成に失敗", err)
 		return
 	}
 
-	//コメント投稿用のJSONデータ作成
+	// コメント投稿用のJSONデータ作成
 	commentJSON := `{"content":"テストコメント"}`
 	postID := 3
 	url := fmt.Sprintf("%s/posts/%d/comments", server.URL, postID)
@@ -42,7 +42,7 @@ func TestPostCommentHandle(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", token)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -50,12 +50,12 @@ func TestPostCommentHandle(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusCreated {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusCreated, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -121,22 +121,22 @@ func TestPostCommentHandleValidation(t *testing.T) {
 
 // コメント削除用APIのテストを実施する
 func TestDeleteCommentHandler(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用サーバーのセットアップ
+	// テスト用サーバーのセットアップ
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//テスト用のJWTトークン発行
+	// テスト用のJWTトークン発行
 	token, err := handler.GenerateJWT(2)
 	if err != nil {
 		t.Fatal("JWTの生成に失敗", err)
 		return
 	}
 
-	//コメント削除用のJSONデータ作成
+	// コメント削除用のJSONデータ作成
 	commentID := 2
 	url := fmt.Sprintf("%s/comments/%d", server.URL, commentID)
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -145,7 +145,7 @@ func TestDeleteCommentHandler(t *testing.T) {
 	}
 	req.Header.Set("Authorization", token)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -153,12 +153,12 @@ func TestDeleteCommentHandler(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusOK, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -166,22 +166,22 @@ func TestDeleteCommentHandler(t *testing.T) {
 
 // コメント削除用APIで他人のコメント削除拒否テストを実施する
 func TestDeleteCommentHandlerUnauthorized(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用サーバーのセットアップ
+	// テスト用サーバーのセットアップ
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//コメント投稿した人以外のユーザーIDを設定する
+	// コメント投稿した人以外のユーザーIDを設定する
 	token, err := handler.GenerateJWT(99)
 	if err != nil {
 		t.Fatal("JWTの生成に失敗", err)
 		return
 	}
 
-	//コメント削除用のJSONデータ作成
+	// コメント削除用のJSONデータ作成
 	commentID := 2
 	url := fmt.Sprintf("%s/comments/%d", server.URL, commentID)
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -190,7 +190,7 @@ func TestDeleteCommentHandlerUnauthorized(t *testing.T) {
 	}
 	req.Header.Set("Authorization", token)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -198,12 +198,12 @@ func TestDeleteCommentHandlerUnauthorized(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusForbidden, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -256,15 +256,15 @@ func TestDeleteCommentHandlerNotFound(t *testing.T) {
 
 // コメント削除用API JWTトークンが無い場合のテストを実施する
 func TestDeleteCommentHandlerNoAuthorization(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用サーバーのセットアップ
+	// テスト用サーバーのセットアップ
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//コメントIDを指定してJSONデータ作成
+	// コメントIDを指定してJSONデータ作成
 	commentID := 2
 	url := fmt.Sprintf("%s/comments/%d", server.URL, commentID)
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -272,7 +272,7 @@ func TestDeleteCommentHandlerNoAuthorization(t *testing.T) {
 		t.Fatal("リクエスト生成失敗:", err)
 	}
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -280,11 +280,11 @@ func TestDeleteCommentHandlerNoAuthorization(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusUnauthorized, resp.StatusCode)
 	}
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -292,18 +292,18 @@ func TestDeleteCommentHandlerNoAuthorization(t *testing.T) {
 
 // コメント削除用API  無効なトークンを送信した場合のテスト
 func TestDeleteCommentHandlerInvalidToken(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用サーバーのセットアップ
+	// テスト用サーバーのセットアップ
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
 	// 改ざんされたトークンを用意
 	invalidToken := "Bearer invalid.jwt.token"
 
-	//コメントIDを指定してJSONデータ作成
+	// コメントIDを指定してJSONデータ作成
 	commentID := 2
 	url := fmt.Sprintf("%s/comments/%d", server.URL, commentID)
 	req, err := http.NewRequest(http.MethodDelete, url, nil)
@@ -312,7 +312,7 @@ func TestDeleteCommentHandlerInvalidToken(t *testing.T) {
 	}
 	req.Header.Set("Authorization", invalidToken)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -320,11 +320,11 @@ func TestDeleteCommentHandlerInvalidToken(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusUnauthorized, resp.StatusCode)
 	}
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 }
@@ -409,7 +409,7 @@ func TestGetCommentsByPostIDHandlerMultiple(t *testing.T) {
 		t.Fatal("リクエスト生成失敗:", err)
 	}
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -417,12 +417,12 @@ func TestGetCommentsByPostIDHandlerMultiple(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusOK, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	var comments []models.Comment
 	if err := json.Unmarshal(body, &comments); err != nil {
@@ -614,7 +614,7 @@ func TestUpdateCommentHandler(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", token)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -622,12 +622,12 @@ func TestUpdateCommentHandler(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusOK, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -663,7 +663,7 @@ func TestUpdateCommentHandlerNotFound(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", token)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -671,12 +671,12 @@ func TestUpdateCommentHandlerNotFound(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusNotFound, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -712,7 +712,7 @@ func TestUpdateCommentHandlerEmptyContent(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", token)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -720,12 +720,12 @@ func TestUpdateCommentHandlerEmptyContent(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusBadRequest, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -753,7 +753,7 @@ func TestUpdateCommentHandlerNoAuthorization(t *testing.T) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -761,12 +761,12 @@ func TestUpdateCommentHandlerNoAuthorization(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusUnauthorized, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 
@@ -802,7 +802,7 @@ func TestUpdateCommentHandlerForbidden(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", token)
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -810,12 +810,12 @@ func TestUpdateCommentHandlerForbidden(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusForbidden, resp.StatusCode)
 	}
 
-	//ログに表示
+	// ログに表示
 	body, _ := io.ReadAll(resp.Body)
 	t.Logf("レスポンス: %s", string(body))
 

--- a/handler/likes.go
+++ b/handler/likes.go
@@ -81,7 +81,10 @@ func GetLikesHandler(db *sql.DB) http.HandlerFunc {
 			UserIDs:   userIDs,
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/handler/likes.go
+++ b/handler/likes.go
@@ -65,7 +65,7 @@ func GetLikesHandler(db *sql.DB) http.HandlerFunc {
 		}
 		defer rows.Close()
 
-		//「いいね」を押してくれたユーザーIDを保管する
+		// 「いいね」を押してくれたユーザーIDを保管する
 		var userIDs []int
 		for rows.Next() {
 			var userID int

--- a/handler/likes.go
+++ b/handler/likes.go
@@ -38,9 +38,11 @@ func LikePostHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		fmt.Fprintln(w, "Post liked successfully")
+		if _, err := fmt.Fprintln(w, "Post liked successfully"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
-
 }
 
 // 指定した投稿の「いいね」数とユーザーを取得する
@@ -113,7 +115,10 @@ func UnlikePostHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		fmt.Fprintln(w, "like removed successfully!")
+		if _, err := fmt.Fprintln(w, "like removed successfully!"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusNoContent)
 	}
 

--- a/handler/likes_test.go
+++ b/handler/likes_test.go
@@ -15,15 +15,15 @@ import (
 
 // いいね設定用APIのテスト
 func TestLikePostHandler(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用サーバーのセットアップ
+	// テスト用サーバーのセットアップ
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//テスト用のJWTトークン発行
+	// テスト用のJWTトークン発行
 	userID := 1
 	token, err := handler.GenerateJWT(userID)
 	if err != nil {
@@ -31,11 +31,11 @@ func TestLikePostHandler(t *testing.T) {
 		return
 	}
 
-	//いいね設定用
+	// いいね設定用
 	postID := 1
 	url := fmt.Sprintf("%s/posts/%d/like", server.URL, postID)
 
-	//おなじリクエストを送信して重複登録されないことを確認する
+	// 同じリクエストを送信して重複登録されないことを確認する
 	for i := 1; i <= 2; i++ {
 		req, err := http.NewRequest(http.MethodPost, url, nil)
 		if err != nil {
@@ -43,7 +43,7 @@ func TestLikePostHandler(t *testing.T) {
 		}
 		req.Header.Set("Authorization", token)
 
-		//リクエスト送信
+		// リクエスト送信
 		client := server.Client()
 		resp, err := client.Do(req)
 		if err != nil {
@@ -51,17 +51,17 @@ func TestLikePostHandler(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		//ステータスコード確認
+		// ステータスコード確認
 		if resp.StatusCode != http.StatusCreated {
 			t.Errorf("[%d回目] 期待するステータスコード %d, 実際は %d", i, http.StatusCreated, resp.StatusCode)
 		}
 
-		//ログに表示
+		// ログに表示
 		body, _ := io.ReadAll(resp.Body)
 		t.Logf("[%d回目] レスポンス: %s", i, string(body))
 	}
 
-	//いいねが1個であることを確認する
+	// いいねが1個であることを確認する
 	var count int
 	err = db.QueryRow("SELECT COUNT(*) FROM likes WHERE user_id = $1 AND post_id = $2", userID, postID).Scan(&count)
 	if err != nil {
@@ -75,15 +75,15 @@ func TestLikePostHandler(t *testing.T) {
 
 // いいね取得用APIのテスト
 func TestGetLikesHandler(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用サーバーのセットアップ
+	// テスト用サーバーのセットアップ
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//いいねを取得する投稿
+	// いいねを取得する投稿
 	postID := 1
 	url := fmt.Sprintf("%s/posts/%d/likes", server.URL, postID)
 
@@ -92,7 +92,7 @@ func TestGetLikesHandler(t *testing.T) {
 		t.Fatal("リクエスト生成失敗:", err)
 	}
 
-	//リクエスト送信
+	// リクエスト送信
 	client := server.Client()
 	resp, err := client.Do(req)
 	if err != nil {
@@ -100,18 +100,18 @@ func TestGetLikesHandler(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	//ステータスコード確認
+	// ステータスコード確認
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusOK, resp.StatusCode)
 	}
 
-	//レスポンスをパースして検証
+	// レスポンスをパースして検証
 	var result models.LikesResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		t.Fatalf("JSONのデコード失敗: %v", err)
 	}
 
-	//結果を比較する
+	// 結果を比較する
 	if result.PostID != postID {
 		t.Errorf("PostID が一致しない: get %d, want %d", result.PostID, postID)
 	}
@@ -119,6 +119,6 @@ func TestGetLikesHandler(t *testing.T) {
 		t.Errorf("like_count (%d) と user_ids の数 (%d) が一致しません", result.LikeCount, len(result.UserIDs))
 	}
 
-	//ログに表示
+	// ログに表示
 	t.Logf("取得したいいねの情報: %+v", result)
 }

--- a/handler/posts.go
+++ b/handler/posts.go
@@ -190,7 +190,10 @@ func UpdatePostHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "Post update successfully!")
+		if _, err := fmt.Fprintln(w, "Post update successfully!"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -246,7 +249,10 @@ func DeletePostHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
-		fmt.Fprintln(w, "Post deleted successfully!")
+		if _, err := fmt.Fprintln(w, "Post deleted successfully!"); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/handler/posts.go
+++ b/handler/posts.go
@@ -41,7 +41,10 @@ func GetPostsByIDHandler(db *sql.DB) http.HandlerFunc {
 
 		// json形式に変更してレスポンスに書き込む
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(post)
+		if err := json.NewEncoder(w).Encode(post); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -99,7 +102,10 @@ func CreatePostHandler(db *sql.DB) http.HandlerFunc {
 		// 作成した記事IDをJSONで返す
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(post)
+		if err := json.NewEncoder(w).Encode(post); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -274,7 +280,10 @@ func GetMyPostsHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(posts)
+		if err := json.NewEncoder(w).Encode(posts); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -300,6 +309,9 @@ func GetAllPostsHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(posts)
+		if err := json.NewEncoder(w).Encode(posts); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }

--- a/handler/posts_test.go
+++ b/handler/posts_test.go
@@ -16,11 +16,11 @@ import (
 
 // 全投稿を取得するAPIのテスト
 func TestGetAllPostsHandler(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
@@ -51,28 +51,26 @@ func TestGetAllPostsHandler(t *testing.T) {
 		t.Logf("取得した投稿データ: \n%s", postsJSON)
 	}
 
-	// Todo: Getした内容がただしかを比較する処理を追加
-
 }
 
 // 投稿作成用APIのテスト
 func TestCreatePostHandler(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//JWTトークンを発行
+	// JWTトークンを発行
 	token, err := handler.GenerateJWT(3)
 	if err != nil {
 		t.Fatal("JWTの生成に失敗:", err)
 		return
 	}
 
-	//JSONデータを構築
+	// JSONデータを構築
 	postJSON := `{"title": "テスト投稿", "content": "これはテスト用です"}`
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/posts", strings.NewReader(postJSON))
 	if err != nil {
@@ -98,15 +96,15 @@ func TestCreatePostHandler(t *testing.T) {
 
 // 投稿作成用API 無効なトークンを送信した場合のテストを実施する
 func TestCreatePostHandlerUnauthorized(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//JSONデータを構築
+	// JSONデータを構築
 	postJSON := `{"title": "テスト投稿", "content": "これはテスト用です"}`
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/posts", strings.NewReader(postJSON))
 	if err != nil {
@@ -131,18 +129,18 @@ func TestCreatePostHandlerUnauthorized(t *testing.T) {
 
 // 投稿作成用API JWTトークンが無い場合のテストを実施する
 func TestCreatePostHandlerInvalidToken(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
 	// 無効なJWTトークン（文字列を壊す）
 	token := "Bearer invalid.token.here"
 
-	//JSONデータを構築
+	// JSONデータを構築
 	postJSON := `{"title": "テスト投稿", "content": "これはテスト用です"}`
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/posts", strings.NewReader(postJSON))
 	if err != nil {
@@ -168,22 +166,22 @@ func TestCreatePostHandlerInvalidToken(t *testing.T) {
 
 // 投稿作成用API 不正なリクエストのテストを実施する
 func TestCreatePostHandlerInvalidJSON(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//JWTトークンを発行
+	// JWTトークンを発行
 	token, err := handler.GenerateJWT(3)
 	if err != nil {
 		t.Fatal("JWTの生成に失敗:", err)
 		return
 	}
 
-	//不正なJSONデータを作成
+	// 不正なJSONデータを作成
 	postJSON := `{"title": "テスト投稿", "content":}`
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/posts", strings.NewReader(postJSON))
 	if err != nil {
@@ -209,22 +207,22 @@ func TestCreatePostHandlerInvalidJSON(t *testing.T) {
 
 // 投稿作成用API タイトルが空のテストを実施する
 func TestCreatePostHandlerMissingTitle(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//JWTトークンを発行
+	// JWTトークンを発行
 	token, err := handler.GenerateJWT(3)
 	if err != nil {
 		t.Fatal("JWTの生成に失敗:", err)
 		return
 	}
 
-	//タイトルが空のJSONデータを作成
+	// タイトルが空のJSONデータを作成
 	postJSON := `{"title": "", "content": "これはテスト用です"}`
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/posts", strings.NewReader(postJSON))
 	if err != nil {
@@ -250,15 +248,15 @@ func TestCreatePostHandlerMissingTitle(t *testing.T) {
 
 // 投稿作成用API バリデーション確認用のテストを実施する
 func TestCreatePostHandlerValidation(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//JWTトークンを発行
+	// JWTトークンを発行
 	token, err := handler.GenerateJWT(3)
 	if err != nil {
 		t.Fatal("JWTの生成に失敗:", err)
@@ -842,15 +840,15 @@ func TestDeletePostHandlerInvalidToken(t *testing.T) {
 
 // 投稿取得用APIのテスト
 func TestGetPostsByIDHandler(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//投稿IDを指定してJSONデータ作成
+	// 投稿IDを指定してJSONデータ作成
 	postID := 1
 	url := fmt.Sprintf("%s/posts/%d", server.URL, postID)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -876,15 +874,15 @@ func TestGetPostsByIDHandler(t *testing.T) {
 
 // 投稿取得用API 存在しない投稿IDのテストを実施
 func TestGetPostsByIDHandlerNotFound(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//存在しない投稿IDを指定してJSONデータ作成
+	// 存在しない投稿IDを指定してJSONデータ作成
 	postID := 9999
 	url := fmt.Sprintf("%s/posts/%d", server.URL, postID)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -910,15 +908,15 @@ func TestGetPostsByIDHandlerNotFound(t *testing.T) {
 
 // 投稿取得用API IDが数値でないテストを実施
 func TestGetPostsByIDHandlerInvalidID(t *testing.T) {
-	//テスト用DBのセットアップを開始する
+	// テスト用DBのセットアップを開始する
 	db := testutils.SetupTestDB(t)
 	defer db.Close()
 
-	//テスト用のサーバーを作成する
+	// テスト用のサーバーを作成する
 	server := httptest.NewServer(testutils.SetupTestServer(db))
 	defer server.Close()
 
-	//数値以外のIDを指定してJSONデータ作成
+	// 数値以外のIDを指定してJSONデータ作成
 	url := fmt.Sprintf("%s/posts/aaa", server.URL)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/handler/users.go
+++ b/handler/users.go
@@ -62,7 +62,10 @@ func SignupHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		json.NewEncoder(w).Encode(userData)
+		if err := json.NewEncoder(w).Encode(userData); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -127,7 +130,10 @@ func LoginHandler(db *sql.DB) http.HandlerFunc {
 
 		// レスポンス
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"token": token})
+		if err := json.NewEncoder(w).Encode(map[string]string{"token": token}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 }
 

--- a/handler/users.go
+++ b/handler/users.go
@@ -142,7 +142,7 @@ func GenerateJWT(userID int) (string, error) {
 	// payloadの生成
 	claims := &jwt.MapClaims{
 		"user_id": userID,
-		"exp":     time.Now().Add(24 * time.Hour).Unix(), //トークンの有効時間(24時間後)
+		"exp":     time.Now().Add(24 * time.Hour).Unix(), // トークンの有効時間(24時間後)
 	}
 
 	// JWTを生成する

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ func main() {
 	if err != nil {
 		log.Fatal("DB接続失敗:", err)
 	}
-	defer db.DB.Close()
 
 	// ポート取得
 	port := os.Getenv("PORT")
@@ -35,7 +34,9 @@ func main() {
 
 	// サーバー起動
 	if err := http.ListenAndServe(":"+port, handler); err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		os.Exit(1)
 	}
+	defer db.DB.Close()
 	log.Println("Server started at :8080")
 }

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -6,7 +6,7 @@ import "net/http"
 func CorsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// CORSヘッダーを設定
-		w.Header().Set("Access-Control-Allow-Origin", "*") //実環境では任意のドメインにする
+		w.Header().Set("Access-Control-Allow-Origin", "*") // 実環境では任意のドメインにする
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 

--- a/router/routers.go
+++ b/router/routers.go
@@ -11,23 +11,23 @@ import (
 // ハンドラー関数の設定を行う
 func RegisterRoutes(r *mux.Router, db *sql.DB) {
 	// 投稿関係の処理
-	r.HandleFunc("/posts", handler.GetAllPostsHandler(db)).Methods("GET")                                   //全投稿取得用
-	r.HandleFunc("/posts/{id}", handler.GetPostsByIDHandler(db)).Methods("GET")                             //個別投稿取得用
-	r.HandleFunc("/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db))).Methods("POST")        //個別投稿作成用
-	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db))).Methods("PUT")    //個別投稿更新用
-	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db))).Methods("DELETE") //個別投稿削除用
-	r.HandleFunc("/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(db))).Methods("GET")       //自身の投稿のみ取得
+	r.HandleFunc("/posts", handler.GetAllPostsHandler(db)).Methods("GET")                                   // 全投稿取得用
+	r.HandleFunc("/posts/{id}", handler.GetPostsByIDHandler(db)).Methods("GET")                             // 個別投稿取得用
+	r.HandleFunc("/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db))).Methods("POST")        // 個別投稿作成用
+	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db))).Methods("PUT")    // 個別投稿更新用
+	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db))).Methods("DELETE") // 個別投稿削除用
+	r.HandleFunc("/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(db))).Methods("GET")       // 自身の投稿のみ取得
 	// ユーザー認証系
-	r.HandleFunc("/signup", handler.SignupHandler(db)) //ユーザー登録用
-	r.HandleFunc("/login", handler.LoginHandler(db))   //ログイン用
+	r.HandleFunc("/signup", handler.SignupHandler(db)) // ユーザー登録用
+	r.HandleFunc("/login", handler.LoginHandler(db))   // ログイン用
 	// コメント関係
-	r.HandleFunc("/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db)).Methods("GET")                     //投稿のコメント取得
-	r.HandleFunc("/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db))).Methods("POST") //投稿のコメント投稿
-	r.HandleFunc("/comments/{id}", handler.GetCommentsByIDHandler(db)).Methods("GET")                               //コメントIDで詳細取得
-	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db))).Methods("DELETE")   //コメントIDで削除
-	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db))).Methods("PUT")      //コメントを更新する
+	r.HandleFunc("/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db)).Methods("GET")                     // 投稿のコメント取得
+	r.HandleFunc("/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db))).Methods("POST") // 投稿のコメント投稿
+	r.HandleFunc("/comments/{id}", handler.GetCommentsByIDHandler(db)).Methods("GET")                               // コメントIDで詳細取得
+	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db))).Methods("DELETE")   // コメントIDで削除
+	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db))).Methods("PUT")      // コメントを更新する
 	// 「いいね」関係
-	r.HandleFunc("/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db))).Methods("POST")     //投稿にいいねをつける
-	r.HandleFunc("/posts/{id}/likes", handler.GetLikesHandler(db)).Methods("GET")                                //投稿のいいねを取得する
-	r.HandleFunc("/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db))).Methods("DELETE") //投稿のいいねを削除する
+	r.HandleFunc("/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db))).Methods("POST")     // 投稿にいいねをつける
+	r.HandleFunc("/posts/{id}/likes", handler.GetLikesHandler(db)).Methods("GET")                                // 投稿のいいねを取得する
+	r.HandleFunc("/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db))).Methods("DELETE") // 投稿のいいねを削除する
 }

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"database/sql"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,7 +18,9 @@ import (
 // 初期化処理
 func init() {
 	// 環境変数の読み込みを実施
-	godotenv.Load("../.env")
+	if err := godotenv.Load("../.env"); err != nil {
+		log.Printf("warning: could not load .env file: %v", err)
+	}
 }
 
 // テスト用のDBを設定する

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -39,7 +39,7 @@ func SetupTestDB(t *testing.T) *sql.DB {
 	if err != nil {
 		t.Fatalf("DB接続失敗: %v", err)
 	}
-	//テスト用のSQLを読み込んで実行する
+	// テスト用のSQLを読み込んで実行する
 	loadTestSQL(t, db, getTestdataPath("init_test.sql"))
 
 	return db
@@ -64,17 +64,17 @@ func loadTestSQL(t *testing.T, db *sql.DB, filepath string) {
 // テスト用のサーバーを設定する
 func SetupTestServer(db *sql.DB) http.Handler {
 	r := mux.NewRouter()
-	r.HandleFunc("/posts", handler.GetAllPostsHandler(db)).Methods("GET")                                           //全投稿取得用
-	r.HandleFunc("/posts/{id}", handler.GetPostsByIDHandler(db)).Methods("GET")                                     //個別投稿取得用
-	r.HandleFunc("/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db))).Methods("POST")                //個別投稿作成用
-	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db))).Methods("PUT")            //個別投稿更新用
-	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db))).Methods("DELETE")         //個別投稿削除用
-	r.HandleFunc("/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db))).Methods("POST") //コメント投稿
-	r.HandleFunc("/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db)).Methods("GET")                     //投稿のコメント取得
-	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db))).Methods("DELETE")   //コメントIDで削除
-	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db))).Methods("PUT")      //コメントを更新する
-	r.HandleFunc("/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db))).Methods("POST")        //投稿にいいねをつける
-	r.HandleFunc("/posts/{id}/likes", handler.GetLikesHandler(db)).Methods("GET")                                   //投稿のいいねを取得する
+	r.HandleFunc("/posts", handler.GetAllPostsHandler(db)).Methods("GET")                                           // 全投稿取得用
+	r.HandleFunc("/posts/{id}", handler.GetPostsByIDHandler(db)).Methods("GET")                                     // 個別投稿取得用
+	r.HandleFunc("/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db))).Methods("POST")                // 個別投稿作成用
+	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db))).Methods("PUT")            // 個別投稿更新用
+	r.HandleFunc("/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db))).Methods("DELETE")         // 個別投稿削除用
+	r.HandleFunc("/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db))).Methods("POST") // コメント投稿
+	r.HandleFunc("/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db)).Methods("GET")                     // 投稿のコメント取得
+	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db))).Methods("DELETE")   // コメントIDで削除
+	r.HandleFunc("/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db))).Methods("PUT")      // コメントを更新する
+	r.HandleFunc("/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db))).Methods("POST")        // 投稿にいいねをつける
+	r.HandleFunc("/posts/{id}/likes", handler.GetLikesHandler(db)).Methods("GET")                                   // 投稿のいいねを取得する
 	return r
 }
 

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"database/sql"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -26,15 +25,14 @@ func SetupTestDB(t *testing.T) *sql.DB {
 	// ヘルパー関数定義（呼び出し元のエラーを表示する）
 	t.Helper()
 	// DB接続設定
-	dbHost := "localhost"
-	dbPort := os.Getenv("DB_TEST_PORT")
-	dbUser := os.Getenv("DB_USER")
-	dbPassword := os.Getenv("DB_PASSWORD")
-	dbName := os.Getenv("DB_TEST_NAME")
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		// ローカル開発用のデフォルト値
+		dbURL = "postgres://postgres:yourpassword@localhost:5433/blog_test?sslmode=disable"
+	}
 
-	// Data Souce Nameの設定
-	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable", dbHost, dbPort, dbUser, dbPassword, dbName)
-	db, err := sql.Open("postgres", dsn)
+	// DB接続
+	db, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		t.Fatalf("DB接続失敗: %v", err)
 	}


### PR DESCRIPTION
## 作業のチケット番号
<!-- 関連するチケット番号があれば記載 -->
- ポートフォリオ作成のためチケットはなし

## 概要
<!-- 変更内容の簡単な説明を記述 -->
- GitHub Actionsに自動テストを追加し、pushや1日1回はアプリのテストを実施するように変更

## 設計書
<!-- 必要に応じて追加情報を記述 -->
- なし

## 変更内容
<!-- 具体的な変更点のリストを記述 -->
- 静的解析Lintを導入
    - 指摘されたコードの内容を修正 
- GO `testing` パッケージによるRESTAPIのテストをActions上で実施するように変更
- docker composeをV1からV2に変更

## テスト方法
<!-- テスト方法を記述 -->
- GitHub Actions上での自動テスト結果を持ってOKと判断

## チェックリスト
<!-- 必要に応じて追加情報を記述 -->
- [x] ビルド成功
- [x] 自動テスト成功
- [x] リファクタリング
- [x] コメントは適切である
- [x] 不要なSleepは設けていない