### PR TITLE
ハンドラー関数の処理成功時に監視ワーカープールにイベントキューを送信してログ出力する実装を追加

### DIFF
--- a/internal/handler/audit.go
+++ b/internal/handler/audit.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"context"
+	"log"
+
+	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
+)
+
+// 監視イベントをワーカープールに追加するためのユーティリティ関数
+func enqueueAuditEvent(ctx context.Context, auditPool *workerpool.AuditWorkerPool, event workerpool.AuditEvent) {
+	if auditPool == nil {
+		return
+	}
+	if err := auditPool.Enqueue(ctx, event); err != nil {
+		log.Printf("Failed to enqueue audit event: %v", err)
+	}
+}

--- a/internal/handler/comments.go
+++ b/internal/handler/comments.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
 	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
 	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
 )
 
 const (
@@ -32,7 +33,7 @@ const (
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/comments [get]
-func GetCommentsByPostIDHandler(db *sql.DB) http.HandlerFunc {
+func GetCommentsByPostIDHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -86,6 +87,9 @@ func GetCommentsByPostIDHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comments_fetched", PostID: postID})
 	}
 }
 
@@ -104,7 +108,7 @@ func GetCommentsByPostIDHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/comments/{id} [get]
-func GetCommentsByIDHandler(db *sql.DB) http.HandlerFunc {
+func GetCommentsByIDHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -135,6 +139,9 @@ func GetCommentsByIDHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_fetched", UserID: comment.UserID, PostID: comment.PostID})
 	}
 }
 
@@ -157,7 +164,7 @@ func GetCommentsByIDHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/comments [post]
-func PostCommentHandler(db *sql.DB) http.HandlerFunc {
+func PostCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -220,6 +227,8 @@ func PostCommentHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_created", UserID: comment.UserID, PostID: comment.PostID})
 	}
 }
 
@@ -242,7 +251,7 @@ func PostCommentHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/comments/{id} [delete]
-func DeleteCommentHandler(db *sql.DB) http.HandlerFunc {
+func DeleteCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -264,8 +273,8 @@ func DeleteCommentHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		// コメントの所有者か確認する
-		var commentOwnerID int
-		err = db.QueryRowContext(ctx, "SELECT user_id FROM comments WHERE id = $1", commentID).Scan(&commentOwnerID)
+		var commentOwnerID, postID int
+		err = db.QueryRowContext(ctx, "SELECT user_id, post_id FROM comments WHERE id = $1", commentID).Scan(&commentOwnerID, &postID)
 		if err == sql.ErrNoRows {
 			respondAppError(w, apperror.NewAppError(apperror.TypeNotFound, "Comment not found : CommentID="+commentIDStr, err))
 			return
@@ -293,6 +302,9 @@ func DeleteCommentHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_deleted", UserID: userID, PostID: postID})
 	}
 }
 
@@ -319,7 +331,7 @@ func DeleteCommentHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/comments/{id} [put]
-func UpdateCommentHandler(db *sql.DB) http.HandlerFunc {
+func UpdateCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -362,8 +374,8 @@ func UpdateCommentHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		// コメントの所有者か確認
-		var existringUserID int
-		err = db.QueryRowContext(ctx, "SELECT user_id FROM comments WHERE id = $1", commentID).Scan(&existringUserID)
+		var existringUserID, postID int
+		err = db.QueryRowContext(ctx, "SELECT user_id, post_id FROM comments WHERE id = $1", commentID).Scan(&existringUserID, &postID)
 		if err == sql.ErrNoRows {
 			respondAppError(w, apperror.NewAppError(apperror.TypeNotFound, "Comment not found : CommentID="+commentIDStr, err))
 			return
@@ -388,5 +400,8 @@ func UpdateCommentHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_updated", UserID: userID, PostID: postID})
 	}
 }

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
+	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
 )
 
 // HealthzHandler godoc
@@ -18,8 +19,10 @@ import (
 // @Success 200 {string} string "OK"
 // @Failure 405 {object} models.ErrorResponse
 // @Router /api/healthz [get]
-func HealthzHandler() http.HandlerFunc {
+func HealthzHandler(auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
 			respondAppError(w, apperror.NewAppError(apperror.TypeMethodNotAllowed, "Method Not Allowed", nil))
 			return
@@ -30,5 +33,8 @@ func HealthzHandler() http.HandlerFunc {
 			log.Printf("failed to write response: %v", err)
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "health_checked"})
 	}
 }

--- a/internal/handler/likes.go
+++ b/internal/handler/likes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
 	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
 	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
 )
 
 // LikePostHandler godoc
@@ -29,7 +30,7 @@ import (
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/like [post]
-func LikePostHandler(db *sql.DB) http.HandlerFunc {
+func LikePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -62,6 +63,9 @@ func LikePostHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_liked", UserID: userID, PostID: postID})
 	}
 }
 
@@ -79,7 +83,7 @@ func LikePostHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/likes [get]
-func GetLikesHandler(db *sql.DB) http.HandlerFunc {
+func GetLikesHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -129,6 +133,9 @@ func GetLikesHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "likes_fetched", PostID: postID})
 	}
 }
 
@@ -148,7 +155,7 @@ func GetLikesHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/like [delete]
-func UnlikePostHandler(db *sql.DB) http.HandlerFunc {
+func UnlikePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -180,6 +187,8 @@ func UnlikePostHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_unliked", UserID: userID, PostID: postID})
 		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/handler/posts.go
+++ b/internal/handler/posts.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -36,7 +35,7 @@ const (
 // @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id} [get]
-func GetPostsByIDHandler(db *sql.DB) http.HandlerFunc {
+func GetPostsByIDHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -66,6 +65,9 @@ func GetPostsByIDHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to encode response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_fetched", UserID: post.UserID, PostID: post.ID})
 	}
 }
 
@@ -141,9 +143,7 @@ func CreatePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.H
 		}
 
 		// 監視ワーカープールにイベントを追加
-		if err := auditPool.Enqueue(ctx, workerpool.AuditEvent{Action: "post_created", UserID: post.UserID, PostID: post.ID}); err != nil {
-			log.Printf("Failed to enqueue audit event: %v", err)
-		}
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_created", UserID: post.UserID, PostID: post.ID})
 
 		// 作成した記事IDをJSONで返す
 		w.Header().Set("Content-Type", "application/json")
@@ -178,7 +178,7 @@ func CreatePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.H
 // @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id} [put]
-func UpdatePostHandler(db *sql.DB) http.HandlerFunc {
+func UpdatePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -260,6 +260,9 @@ func UpdatePostHandler(db *sql.DB) http.HandlerFunc {
 			return
 		}
 
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_updated", UserID: userID, PostID: id})
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		if err := json.NewEncoder(w).Encode(post); err != nil {
@@ -291,7 +294,7 @@ func UpdatePostHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id} [put]
-func DeletePostHandler(db *sql.DB) http.HandlerFunc {
+func DeletePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -349,6 +352,8 @@ func DeletePostHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_deleted", UserID: userID, PostID: id})
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
@@ -369,7 +374,7 @@ func DeletePostHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/myposts [get]
-func GetMyPostsHandler(db *sql.DB) http.HandlerFunc {
+func GetMyPostsHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -410,6 +415,9 @@ func GetMyPostsHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "my_posts_fetched", UserID: userID})
 	}
 }
 
@@ -427,7 +435,7 @@ func GetMyPostsHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts [get]
-func GetAllPostsHandler(db *sql.DB) http.HandlerFunc {
+func GetAllPostsHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -463,5 +471,8 @@ func GetAllPostsHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "posts_fetched"})
 	}
 }

--- a/internal/handler/users.go
+++ b/internal/handler/users.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
 	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
 	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -30,7 +31,7 @@ import (
 // @Failure 405 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/signup [post]
-func SignupHandler(db *sql.DB) http.HandlerFunc {
+func SignupHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -80,6 +81,9 @@ func SignupHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "user_signed_up", UserID: userData.ID})
 	}
 }
 
@@ -102,7 +106,7 @@ func SignupHandler(db *sql.DB) http.HandlerFunc {
 // @Failure 405 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/login [post]
-func LoginHandler(db *sql.DB) http.HandlerFunc {
+func LoginHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -166,6 +170,9 @@ func LoginHandler(db *sql.DB) http.HandlerFunc {
 			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
 			return
 		}
+
+		// 監視ワーカープールにイベントを追加
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "user_logged_in", UserID: id})
 	}
 }
 

--- a/internal/router/routers.go
+++ b/internal/router/routers.go
@@ -18,25 +18,25 @@ func RegisterRoutes(r *mux.Router, db *sql.DB, auditPool *workerpool.AuditWorker
 	// Swagger UI
 	r.PathPrefix("/swagger/").Handler(httpSwagger.WrapHandler)
 	// ヘルスチェック用
-	r.HandleFunc("/api/healthz", handler.HealthzHandler()).Methods(http.MethodGet, http.MethodHead) // ヘルスチェック用
+	r.HandleFunc("/api/healthz", handler.HealthzHandler(auditPool)).Methods(http.MethodGet, http.MethodHead) // ヘルスチェック用
 	// 投稿関係の処理
-	r.HandleFunc("/api/posts", handler.GetAllPostsHandler(db)).Methods(http.MethodGet)                                       // 全投稿取得用
-	r.HandleFunc("/api/posts/{id}", handler.GetPostsByIDHandler(db)).Methods(http.MethodGet)                                 // 個別投稿取得用
-	r.HandleFunc("/api/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db, auditPool))).Methods(http.MethodPost) // 個別投稿作成用
-	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db))).Methods(http.MethodPut)        // 個別投稿更新用
-	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db))).Methods(http.MethodDelete)     // 個別投稿削除用
-	r.HandleFunc("/api/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(db))).Methods(http.MethodGet)           // 自身の投稿のみ取得
+	r.HandleFunc("/api/posts", handler.GetAllPostsHandler(db, auditPool)).Methods(http.MethodGet)                                   // 全投稿取得用
+	r.HandleFunc("/api/posts/{id}", handler.GetPostsByIDHandler(db, auditPool)).Methods(http.MethodGet)                             // 個別投稿取得用
+	r.HandleFunc("/api/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db, auditPool))).Methods(http.MethodPost)        // 個別投稿作成用
+	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db, auditPool))).Methods(http.MethodPut)    // 個別投稿更新用
+	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db, auditPool))).Methods(http.MethodDelete) // 個別投稿削除用
+	r.HandleFunc("/api/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(db, auditPool))).Methods(http.MethodGet)       // 自身の投稿のみ取得
 	// ユーザー認証系
-	r.HandleFunc("/api/signup", handler.SignupHandler(db)).Methods(http.MethodPost) // ユーザー登録用
-	r.HandleFunc("/api/login", handler.LoginHandler(db)).Methods(http.MethodPost)   // ログイン用
+	r.HandleFunc("/api/signup", handler.SignupHandler(db, auditPool)).Methods(http.MethodPost) // ユーザー登録用
+	r.HandleFunc("/api/login", handler.LoginHandler(db, auditPool)).Methods(http.MethodPost)   // ログイン用
 	// コメント関係
-	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db)).Methods(http.MethodGet)                     // 投稿のコメント取得
-	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db))).Methods(http.MethodPost) // 投稿のコメント投稿
-	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(db)).Methods(http.MethodGet)                               // コメントIDで詳細取得
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db))).Methods(http.MethodDelete)   // コメントIDで削除
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db))).Methods(http.MethodPut)      // コメントを更新する
+	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db, auditPool)).Methods(http.MethodGet)                     // 投稿のコメント取得
+	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db, auditPool))).Methods(http.MethodPost) // 投稿のコメント投稿
+	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(db, auditPool)).Methods(http.MethodGet)                               // コメントIDで詳細取得
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db, auditPool))).Methods(http.MethodDelete)   // コメントIDで削除
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db, auditPool))).Methods(http.MethodPut)      // コメントを更新する
 	// 「いいね」関係
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db))).Methods(http.MethodPost)     // 投稿にいいねをつける
-	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db)).Methods(http.MethodGet)                                // 投稿のいいねを取得する
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db))).Methods(http.MethodDelete) // 投稿のいいねを削除する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db, auditPool))).Methods(http.MethodPost)     // 投稿にいいねをつける
+	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db, auditPool)).Methods(http.MethodGet)                                // 投稿のいいねを取得する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db, auditPool))).Methods(http.MethodDelete) // 投稿のいいねを削除する
 }

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -74,17 +74,23 @@ func SetupTestServer(db *sql.DB) (http.Handler, func()) {
 	cleanup := func() {
 		auditPool.Stop()
 	}
-	r.HandleFunc("/api/posts", handler.GetAllPostsHandler(db)).Methods("GET")                                           // 全投稿取得用
-	r.HandleFunc("/api/posts/{id}", handler.GetPostsByIDHandler(db)).Methods("GET")                                     // 個別投稿取得用
-	r.HandleFunc("/api/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db, auditPool))).Methods("POST")     // 個別投稿作成用
-	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db))).Methods("PUT")            // 個別投稿更新用
-	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db))).Methods("DELETE")         // 個別投稿削除用
-	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db))).Methods("POST") // コメント投稿
-	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db)).Methods("GET")                     // 投稿のコメント取得
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db))).Methods("DELETE")   // コメントIDで削除
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db))).Methods("PUT")      // コメントを更新する
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db))).Methods("POST")        // 投稿にいいねをつける
-	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db)).Methods("GET")                                   // 投稿のいいねを取得する
+	r.HandleFunc("/api/healthz", handler.HealthzHandler(auditPool)).Methods(http.MethodGet, http.MethodHead)                       // ヘルスチェック用
+	r.HandleFunc("/api/posts", handler.GetAllPostsHandler(db, auditPool)).Methods("GET")                                           // 全投稿取得用
+	r.HandleFunc("/api/posts/{id}", handler.GetPostsByIDHandler(db, auditPool)).Methods("GET")                                     // 個別投稿取得用
+	r.HandleFunc("/api/posts", middleware.AuthMiddleware(handler.CreatePostHandler(db, auditPool))).Methods("POST")                // 個別投稿作成用
+	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(db, auditPool))).Methods("PUT")            // 個別投稿更新用
+	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(db, auditPool))).Methods("DELETE")         // 個別投稿削除用
+	r.HandleFunc("/api/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(db, auditPool))).Methods("GET")               // 自身の投稿のみ取得
+	r.HandleFunc("/api/signup", handler.SignupHandler(db, auditPool)).Methods("POST")                                              // ユーザー登録用
+	r.HandleFunc("/api/login", handler.LoginHandler(db, auditPool)).Methods("POST")                                                // ログイン用
+	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db, auditPool))).Methods("POST") // コメント投稿
+	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db, auditPool)).Methods("GET")                     // 投稿のコメント取得
+	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(db, auditPool)).Methods("GET")                               // コメントIDで詳細取得
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db, auditPool))).Methods("DELETE")   // コメントIDで削除
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db, auditPool))).Methods("PUT")      // コメントを更新する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db, auditPool))).Methods("POST")        // 投稿にいいねをつける
+	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db, auditPool)).Methods("GET")                                   // 投稿のいいねを取得する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db, auditPool))).Methods("DELETE")    // 投稿のいいねを削除する
 	return r, cleanup
 }
 


### PR DESCRIPTION
## 作業のチケット番号
<!-- 関連するチケット番号があれば記載 -->
- ポートフォリオ作成のためチケットはなし

## 概要
<!-- 変更内容の簡単な説明を記述 -->
- ハンドラー関数処理成功時にイベントキューを追加して監視ワーカープールのゴルーチンでログ出力を実施するように変更
- 投稿作成用のハンドラー関数にのみ処理を実装し、動作確認を実施して問題なかったので他のハンドラー関数にも実装を追加する
- 他のハンドラー関数への展開はcodexのエージェント機能にて実施

## 設計書
<!-- 必要に応じて追加情報を記述 -->
- なし

## 変更内容
<!-- 具体的な変更点のリストを記述 -->
- ハンドラー関数の処理成功時に監視ワーカープールにイベントキューを送信してログ出力する実装を追加 556964a1842dca776b75eccc17f623fbcddddc3f

## テスト方法
<!-- テスト方法を記述 -->
- GitHub ActionsのCI環境にてテストを実施
    - 既存の機能に影響がないことを確認 

## チェックリスト
<!-- 必要に応じて追加情報を記述 -->
- [x] ビルド成功
- [x] 自動テスト成功
- [x] リファクタリング
- [x] コメントは適切である
- [x] 不要なSleepは設けていない