### PR TITLE
[codex] Add Playwright make commands and README command docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,15 @@ PROD=$(DC) -f $(COMPOSE_PROD_FILE)
 TEST=$(DC) -f $(COMPOSE_TEST_FILE)
 FRONT_DIR=blog-api-frontend
 NPM=cd $(FRONT_DIR) && npm
+PLAYWRIGHT=cd $(FRONT_DIR) && npx playwright
+PW_URL?=http://localhost:3000
 
 # ターゲット定義
 .PHONY: help \
 		up-dev up-dev-attach down-dev down-volumes-dev restart-dev logs-dev build-dev rebuild-dev ps-dev \
 		up-prod down-prod restart-prod logs-prod build-prod rebuild-prod ps-prod \
 		up-test down-test down-volumes-test restart-test logs-test build-test rebuild-test ps-test \
-		test-go go-lint test-e2e ci-test wait-test-db \
+		test-go go-lint test-e2e pw-install pw-test pw-ui pw-codegen pw-report ci-test wait-test-db \
 		fe-install fe-dev fe-build fe-preview \
 		migrate migrate-dev migrate-prod
 
@@ -58,6 +60,11 @@ help:
 	@echo "  make test-go              - Run backend handler function tests"
 	@echo "  make go-lint			   - Run golangci-lint checks"
 	@echo "  make test-e2e             - Run E2E tests"
+	@echo "  make pw-install           - Install Playwright browsers"
+	@echo "  make pw-test              - Run Playwright tests"
+	@echo "  make pw-ui                - Run Playwright tests with UI mode"
+	@echo "  make pw-codegen           - Open Playwright codegen (PW_URL=http://localhost:3000)"
+	@echo "  make pw-report            - Open Playwright HTML report"
 	@echo "  make ci-test              - Run all CI tests"
 	@echo ""	
 	@echo "  make fe-install           - Install frontend dependencies"
@@ -165,7 +172,27 @@ test-e2e:
 	@set -e; \
 	trap 'cd $(CURDIR) && $(MAKE) down-volumes-dev' EXIT; \
 	$(MAKE) down-volumes-dev; \
-	cd blog-api-frontend && npx playwright test
+	$(PLAYWRIGHT) test
+
+# Playwrightブラウザのインストール
+pw-install:
+	$(PLAYWRIGHT) install
+
+# Playwrightテスト実行
+pw-test:
+	$(PLAYWRIGHT) test
+
+# Playwright UIモードでテスト実行
+pw-ui:
+	$(PLAYWRIGHT) test --ui
+
+# Playwright Codegenを起動
+pw-codegen:
+	$(PLAYWRIGHT) codegen $(PW_URL)
+
+# Playwright HTMLレポートを表示
+pw-report:
+	$(PLAYWRIGHT) show-report
 
 # CIのテストをまとめて実行
 ci-test: go-lint test-go test-e2e

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ test-e2e:
 	$(PLAYWRIGHT) test
 
 # Playwrightブラウザのインストール
-pw-install:
+pw-install: fe-install
 	$(PLAYWRIGHT) install
 
 # Playwrightテスト実行

--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ make test-go
 
 makeコマンドを使用して実行することができます。
 
+初回のみPlaywright用ブラウザをインストールします。
+
+```bash
+make pw-install
+```
+
 実行コマンド：
 
 ```bash
@@ -218,6 +224,8 @@ make test-e2e
 
 - `blog-api-frontend/playwright.config.ts`が`docker compose ... up --build frontend`を実行して環境を立ち上げます。
 - global-setup で API の起動待ち + テストユーザー作成を行います。
+- UIモードで確認したい場合は`make pw-ui`、操作を記録しながらテストを作る場合は`make pw-codegen`を使用します。
+- Codegenの起動URLを変えたい場合は`make pw-codegen PW_URL=http://localhost:3000/posts`のように指定できます。
 
 ---
 
@@ -355,14 +363,24 @@ BlogAPIで使用できる主要な`make`コマンドです。
 ```bash
 make up-dev        # 開発環境起動（docker-compose.yml 使用）
 make down-dev      # 開発環境停止
+make logs-dev      # 開発環境ログ表示
+make ps-dev        # 開発環境コンテナ状態確認
 make test-go       # Backendテスト実行（test用compose起動 → DB初期化 → go test）
 make test-e2e      # E2Eテスト実行（Playwright）
+make pw-install    # Playwright用ブラウザをインストール
+make pw-test       # Playwrightテスト実行
+make pw-ui         # Playwright UIモードでテスト実行
+make pw-codegen    # Playwright Codegen起動（PW_URLでURL指定可）
+make pw-report     # Playwright HTMLレポート表示
+make go-lint       # golangci-lint実行
 make ci-test       # CI相当のまとめ実行
 make migrate       # ローカル環境からDBマイグレーション実行
 make migrate-dev   # 開発用appコンテナ内でDBマイグレーション実行
 make migrate-prod  # 本番用appコンテナ内でDBマイグレーション実行
 make fe-install    # フロントエンド依存関係インストール
 make fe-dev        # フロント開発サーバー起動（Vite）
+make fe-build      # フロントエンドビルド
+make fe-preview    # フロントエンドビルドのプレビュー起動
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add Makefile targets for common Playwright workflows: browser install, test, UI mode, codegen, and report viewing.
- Reuse a shared Playwright command variable from the existing E2E target.
- Document Playwright setup and the main Makefile commands in README.

## Impact
Developers can run and discover E2E-related commands from the repository root without moving into the frontend directory manually.

## Validation
- Confirmed `make -n help` parses successfully from WSL.
- Confirmed the branch diff against `main` contains only `Makefile` and `README.md`.