### PR TITLE
ハンドラー関数の責務分離を実施

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ flowchart LR
 
 - `.github` : GitHub ActionsのWorkflow / PRのテンプレートなど
 - `cmd/api/` : APIサーバーのエントリポイント  
-- `internal/` : handler / middleware / repository などアプリ本体  
+- `internal/` : handler / service / repository / middleware などアプリ本体  
 - `infra/` : docker-compose（dev/test/prod）/ nginx設定 / utility
 - `blog-api-frontend/` : Reactフロント（PlaywrightによるE2Eテスト含む）  
 - `sql/` : DB初期化用SQL / マイグレーションSQL

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -47,6 +47,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -96,7 +102,10 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Comment"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -160,7 +169,10 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Comment"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -171,6 +183,18 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -212,7 +236,7 @@ const docTemplate = `{
         },
         "/api/login": {
             "post": {
-                "description": "送られてきたユーザー情報でログインする\n\n**エラー条件:**\n- 無効なユーザー情報、ユーザー名が空、パスワードが8文字未満 → 400 Bad Request\n- ユーザー名かパスワードが不正 → 401 Unauthorized\n- 許可されていないメソッド → 405 MethodNotAllowed\n- データ更新/取得失敗、JWT生成失敗、レスポンス書き込み失敗 → 500 ServerError",
+                "description": "送られてきたユーザー情報でログインする\n\n**エラー条件:**\n- 無効なユーザー情報、ユーザー名が空、パスワードが空 → 400 Bad Request\n- ユーザー名かパスワードが不正 → 401 Unauthorized\n- 許可されていないメソッド → 405 MethodNotAllowed\n- データ更新/取得失敗、JWT生成失敗、レスポンス書き込み失敗 → 500 ServerError",
                 "consumes": [
                     "application/json"
                 ],
@@ -602,8 +626,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/models.Comment"
                         }
@@ -636,7 +660,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "comments"
+                    "likes"
                 ],
                 "summary": "投稿に「いいね」をつける",
                 "parameters": [
@@ -650,9 +674,12 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "Post liked successfully",
+                        "description": "Created",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -681,7 +708,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "comments"
+                    "likes"
                 ],
                 "summary": "投稿の「いいね」を削除する",
                 "parameters": [
@@ -695,10 +722,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -728,7 +752,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "tags": [
-                    "comments"
+                    "likes"
                 ],
                 "summary": "投稿の「いいね」を取得する",
                 "parameters": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -44,6 +44,12 @@
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
@@ -93,7 +99,10 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Comment"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -157,7 +166,10 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/models.Comment"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -168,6 +180,18 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/models.ErrorResponse"
                         }
@@ -209,7 +233,7 @@
         },
         "/api/login": {
             "post": {
-                "description": "送られてきたユーザー情報でログインする\n\n**エラー条件:**\n- 無効なユーザー情報、ユーザー名が空、パスワードが8文字未満 → 400 Bad Request\n- ユーザー名かパスワードが不正 → 401 Unauthorized\n- 許可されていないメソッド → 405 MethodNotAllowed\n- データ更新/取得失敗、JWT生成失敗、レスポンス書き込み失敗 → 500 ServerError",
+                "description": "送られてきたユーザー情報でログインする\n\n**エラー条件:**\n- 無効なユーザー情報、ユーザー名が空、パスワードが空 → 400 Bad Request\n- ユーザー名かパスワードが不正 → 401 Unauthorized\n- 許可されていないメソッド → 405 MethodNotAllowed\n- データ更新/取得失敗、JWT生成失敗、レスポンス書き込み失敗 → 500 ServerError",
                 "consumes": [
                     "application/json"
                 ],
@@ -599,8 +623,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
+                    "201": {
+                        "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/models.Comment"
                         }
@@ -633,7 +657,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "comments"
+                    "likes"
                 ],
                 "summary": "投稿に「いいね」をつける",
                 "parameters": [
@@ -647,9 +671,12 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "Post liked successfully",
+                        "description": "Created",
                         "schema": {
-                            "type": "string"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
@@ -678,7 +705,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "comments"
+                    "likes"
                 ],
                 "summary": "投稿の「いいね」を削除する",
                 "parameters": [
@@ -692,10 +719,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -725,7 +749,7 @@
                     "application/json"
                 ],
                 "tags": [
-                    "comments"
+                    "likes"
                 ],
                 "summary": "投稿の「いいね」を取得する",
                 "parameters": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -97,13 +97,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Comment'
+            additionalProperties:
+              type: string
+            type: object
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/models.ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Not Found
           schema:
             $ref: '#/definitions/models.ErrorResponse'
         "500":
@@ -136,6 +146,10 @@ paths:
             $ref: '#/definitions/models.Comment'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/models.ErrorResponse'
+        "404":
+          description: Not Found
           schema:
             $ref: '#/definitions/models.ErrorResponse'
         "500":
@@ -180,7 +194,9 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/models.Comment'
+            additionalProperties:
+              type: string
+            type: object
         "400":
           description: Bad Request
           schema:
@@ -233,7 +249,7 @@ paths:
         送られてきたユーザー情報でログインする
 
         **エラー条件:**
-        - 無効なユーザー情報、ユーザー名が空、パスワードが8文字未満 → 400 Bad Request
+        - 無効なユーザー情報、ユーザー名が空、パスワードが空 → 400 Bad Request
         - ユーザー名かパスワードが不正 → 401 Unauthorized
         - 許可されていないメソッド → 405 MethodNotAllowed
         - データ更新/取得失敗、JWT生成失敗、レスポンス書き込み失敗 → 500 ServerError
@@ -533,8 +549,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
+        "201":
+          description: Created
           schema:
             $ref: '#/definitions/models.Comment'
         "400":
@@ -572,8 +588,6 @@ paths:
       responses:
         "204":
           description: No Content
-          schema:
-            type: string
         "400":
           description: Bad Request
           schema:
@@ -588,7 +602,7 @@ paths:
             $ref: '#/definitions/models.ErrorResponse'
       summary: 投稿の「いいね」を削除する
       tags:
-      - comments
+      - likes
     post:
       description: |-
         指定したIDの投稿に「いいね」をつける
@@ -607,9 +621,11 @@ paths:
       - application/json
       responses:
         "201":
-          description: Post liked successfully
+          description: Created
           schema:
-            type: string
+            additionalProperties:
+              type: string
+            type: object
         "400":
           description: Bad Request
           schema:
@@ -624,7 +640,7 @@ paths:
             $ref: '#/definitions/models.ErrorResponse'
       summary: 投稿に「いいね」をつける
       tags:
-      - comments
+      - likes
   /api/posts/{id}/likes:
     get:
       description: |-
@@ -656,7 +672,7 @@ paths:
             $ref: '#/definitions/models.ErrorResponse'
       summary: 投稿の「いいね」を取得する
       tags:
-      - comments
+      - likes
   /api/signup:
     post:
       consumes:

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -12,6 +12,7 @@ type Services struct {
 	Post    *service.PostService
 	Comment *service.CommentService
 	Like    *service.LikeService
+	User    *service.UserService
 }
 
 // サービスの初期化を行う関数
@@ -19,10 +20,12 @@ func NewServices(db *sql.DB) *Services {
 	postRepo := repository.NewPostRepository(db)
 	commentRepo := repository.NewCommentRepository(db)
 	likeRepo := repository.NewLikeRepository(db)
+	userRepo := repository.NewUserRepository(db)
 
 	return &Services{
 		Post:    service.NewPostService(postRepo),
 		Comment: service.NewCommentService(commentRepo),
 		Like:    service.NewLikeService(likeRepo),
+		User:    service.NewUserService(userRepo),
 	}
 }

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -11,15 +11,18 @@ import (
 type Services struct {
 	Post    *service.PostService
 	Comment *service.CommentService
+	Like    *service.LikeService
 }
 
 // サービスの初期化を行う関数
 func NewServices(db *sql.DB) *Services {
 	postRepo := repository.NewPostRepository(db)
 	commentRepo := repository.NewCommentRepository(db)
+	likeRepo := repository.NewLikeRepository(db)
 
 	return &Services{
 		Post:    service.NewPostService(postRepo),
 		Comment: service.NewCommentService(commentRepo),
+		Like:    service.NewLikeService(likeRepo),
 	}
 }

--- a/internal/app/services.go
+++ b/internal/app/services.go
@@ -9,14 +9,17 @@ import (
 
 // サービスをまとめる構造体
 type Services struct {
-	Post *service.PostService
+	Post    *service.PostService
+	Comment *service.CommentService
 }
 
 // サービスの初期化を行う関数
 func NewServices(db *sql.DB) *Services {
 	postRepo := repository.NewPostRepository(db)
+	commentRepo := repository.NewCommentRepository(db)
 
 	return &Services{
-		Post: service.NewPostService(postRepo),
+		Post:    service.NewPostService(postRepo),
+		Comment: service.NewCommentService(commentRepo),
 	}
 }

--- a/internal/handler/comments.go
+++ b/internal/handler/comments.go
@@ -1,22 +1,12 @@
 package handler
 
 import (
-	"database/sql"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"strconv"
-	"strings"
 
 	"github.com/gorilla/mux"
-	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
-	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
 	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/service"
 	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
-)
-
-const (
-	MaxCommentLength = 500
 )
 
 // GetCommentsByPostIDHandler godoc
@@ -33,60 +23,28 @@ const (
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/comments [get]
-func GetCommentsByPostIDHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func GetCommentsByPostIDHandler(commentService *service.CommentService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// URIからpostのIDを取得
 		vars := mux.Vars(r)
-		postIDStr := vars["id"]
-		postID, err := strconv.Atoi(postIDStr)
+		postID, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
+			return
+		}
+
+		// 指定した投稿のコメントをすべて取得する
+		comments, err := commentService.GetCommentsByPostID(ctx, postID)
 		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid post ID : PostID="+postIDStr, err))
+			respondAppError(w, err)
 			return
 		}
 
-		// 指定した投稿のコメントを取得する
-		rows, err := db.QueryContext(ctx, `
-			SELECT id, post_id, user_id, content, created_at
-			FROM comments
-			WHERE post_id = $1
-			ORDER BY created_at ASC
-		`, postID)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to fetch comments : PostID="+postIDStr, err))
-			return
-		}
-		defer rows.Close()
-
-		// 取得したコメントをスライスに格納
-		var comments []models.Comment
-		for rows.Next() {
-			var c models.Comment
-			if err := rows.Scan(&c.ID, &c.PostID, &c.UserID, &c.Content, &c.CreatedAt); err != nil {
-				respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Error reading comment : PostID="+postIDStr, err))
-				return
-			}
-			comments = append(comments, c)
-		}
-
-		// rows.Next()のループが終了した後にエラーが発生していないか確認する(DBからのデータ取得中にエラーが発生していないか)
-		if err := rows.Err(); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to fetch comments : PostID="+postIDStr, err))
-			return
-		}
-
-		// コメントがない場合
-		if len(comments) == 0 {
-			fmt.Println("No comments : PostID=" + postIDStr)
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(comments); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		// 指定した投稿のコメントをJSONで返す
+		respondJSON(w, http.StatusOK, comments)
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comments_fetched", PostID: postID})
@@ -106,39 +64,31 @@ func GetCommentsByPostIDHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPoo
 // @Param id path int true "コメントID"
 // @Success 200 {object} models.Comment
 // @Failure 400 {object} models.ErrorResponse
+// @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/comments/{id} [get]
-func GetCommentsByIDHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func GetCommentsByIDHandler(commentService *service.CommentService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// URIからコメントのIDを取得
 		vars := mux.Vars(r)
-		IDStr := vars["id"]
-		ID, err := strconv.Atoi(IDStr)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid comment ID : CommentID="+IDStr, err))
+		id, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// 指定したIDのコメントを取得する
-		var comment models.Comment
-		err = db.QueryRowContext(ctx, "SELECT id, post_id, user_id, content, created_at FROM comments WHERE id = $1", ID).Scan(&comment.ID, &comment.PostID, &comment.UserID, &comment.Content, &comment.CreatedAt)
+		comment, err := commentService.GetCommentByID(ctx, id)
 		if err != nil {
-			if err == sql.ErrNoRows {
-				respondAppError(w, apperror.NewAppError(apperror.TypeNotFound, "Comment Not Found : CommentID="+IDStr, err))
-			} else {
-				respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Database error : CommentID="+IDStr, err))
-			}
+			respondAppError(w, err)
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(comment); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		// 指定したコメントをJSONで返す
+		respondJSON(w, http.StatusOK, comment)
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_fetched", UserID: comment.UserID, PostID: comment.PostID})
@@ -159,73 +109,52 @@ func GetCommentsByIDHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) h
 // @Param Authorization header string true "Bearer Token"
 // @Param id path int true "投稿ID"
 // @Param post body models.Comment true "コメント内容"
-// @Success 200 {object} models.Comment
+// @Success 201 {object} models.Comment
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/comments [post]
-func PostCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func PostCommentHandler(commentService *service.CommentService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// JWTからuser_idを取得
-		userID, ok := ctx.Value(middleware.UserIDKey).(int)
-		if !ok {
-			respondAppError(w, apperror.NewAppError(apperror.TypeUnauthorized, "Unauthorized", nil))
+		userID, appErr := userIDFromContext(ctx)
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// URIからpostのIDを取得
 		vars := mux.Vars(r)
-		postIDStr := vars["id"]
-		postID, err := strconv.Atoi(postIDStr)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid post ID : PostID="+postIDStr, err))
+		postID, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// リクエストボディからコメントを読み取る
 		var comment models.Comment
-		if err := json.NewDecoder(r.Body).Decode(&comment); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid request body : PostID="+postIDStr, err))
+		if appErr := decodeJSON(r, &comment); appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
-		// コメントが空の場合はエラーとする
-		if strings.TrimSpace(comment.Content) == "" {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Content is required : PostID="+postIDStr, nil))
-			return
-		}
-
-		// コメントが500文字以上の場合はエラーとする
-		if len(comment.Content) > MaxCommentLength {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Content must be 500 characters or less : PostID="+postIDStr, nil))
+		// コメントのバリデーションを実施する
+		if err := validateCommentInput(comment, postID); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
 		// コメントを挿入する
-		query := `INSERT INTO comments (post_id, user_id, content) 
-				VALUES ($1, $2, $3)
-				RETURNING id, post_id, user_id, content, created_at`
-
-		err = db.QueryRowContext(ctx, query, postID, userID, comment.Content).Scan(
-			&comment.ID,
-			&comment.PostID,
-			&comment.UserID,
-			&comment.Content,
-			&comment.CreatedAt,
-		)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to insert comment : "+err.Error(), err))
+		if err := commentService.CreateComment(ctx, postID, userID, &comment); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		w.WriteHeader(http.StatusCreated)
-		if err := json.NewEncoder(w).Encode(comment); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		// 作成したコメントをJSONで返す
+		respondJSON(w, http.StatusCreated, comment)
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_created", UserID: comment.UserID, PostID: comment.PostID})
@@ -246,62 +175,48 @@ func PostCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.
 // @Produce json
 // @Param Authorization header string true "Bearer Token"
 // @Param id path int true "コメントID"
-// @Success 200 {object} models.Comment
+// @Success 200 {object} map[string]string
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 401 {object} models.ErrorResponse
+// @Failure 403 {object} models.ErrorResponse
+// @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/comments/{id} [delete]
-func DeleteCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func DeleteCommentHandler(commentService *service.CommentService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// JWTからuser_idを取得
-		userID, ok := ctx.Value(middleware.UserIDKey).(int)
-		if !ok {
-			respondAppError(w, apperror.NewAppError(apperror.TypeUnauthorized, "Unauthorized : User ID not found in context", nil))
+		userID, appErr := userIDFromContext(ctx)
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// URIからcommentのIDを取得
 		vars := mux.Vars(r)
-		commentIDStr := vars["id"]
-		commentID, err := strconv.Atoi(commentIDStr)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid comment ID : CommentID="+commentIDStr, err))
+		commentID, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// コメントの所有者か確認する
-		var commentOwnerID, postID int
-		err = db.QueryRowContext(ctx, "SELECT user_id, post_id FROM comments WHERE id = $1", commentID).Scan(&commentOwnerID, &postID)
-		if err == sql.ErrNoRows {
-			respondAppError(w, apperror.NewAppError(apperror.TypeNotFound, "Comment not found : CommentID="+commentIDStr, err))
-			return
-		} else if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Database error : CommentID="+commentIDStr, err))
-			return
-		}
-
-		// 所有者ではない場合は削除不可
-		if commentOwnerID != userID {
-			respondAppError(w, apperror.NewAppError(apperror.TypeForbidden, "Forbidden : CommentID="+commentIDStr, nil))
+		postID, err := commentService.EnsureCommentOwner(ctx, userID, commentID)
+		if err != nil {
+			respondAppError(w, err)
 			return
 		}
 
 		// コメントを削除する
-		_, err = db.ExecContext(ctx, "DELETE FROM comments WHERE id = $1", commentID)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to delete comment : CommentID="+commentIDStr, err))
+		if err := commentService.DeleteComment(ctx, commentID); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		// リクエスト正常終了
-		w.WriteHeader(http.StatusOK)
-		if _, err := fmt.Fprintln(w, "Comment deleted successfully!"); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		// 削除成功をJSONで返す
+		respondJSON(w, http.StatusOK, map[string]string{"message": "Comment deleted successfully!"})
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_deleted", UserID: userID, PostID: postID})
@@ -324,31 +239,37 @@ func DeleteCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) htt
 // @Param Authorization header string true "Bearer Token"
 // @Param id path int true "コメントID"
 // @Param post body models.Comment true "コメント内容"
-// @Success 200 {object} models.Comment
+// @Success 200 {object} map[string]string
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 403 {object} models.ErrorResponse
 // @Failure 404 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/comments/{id} [put]
-func UpdateCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func UpdateCommentHandler(commentService *service.CommentService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// JWTからuser_idを取得
-		userID, ok := ctx.Value(middleware.UserIDKey).(int)
-		if !ok {
-			respondAppError(w, apperror.NewAppError(apperror.TypeUnauthorized, "Unauthorized : User ID not found in context", nil))
+		userID, appErr := userIDFromContext(ctx)
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// コメントIDを取得
 		vars := mux.Vars(r)
-		commentIDStr := vars["id"]
-		commentID, err := strconv.Atoi(commentIDStr)
+		commentID, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
+			return
+		}
+
+		// コメントの所有者か確認
+		postID, err := commentService.EnsureCommentOwner(ctx, userID, commentID)
 		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid comment ID : CommentID="+commentIDStr, err))
+			respondAppError(w, err)
 			return
 		}
 
@@ -356,50 +277,25 @@ func UpdateCommentHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) htt
 		var req struct {
 			Content string `json:"content"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid request body : CommentID="+commentIDStr, err))
+		if appErr := decodeJSON(r, &req); appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
-		// コメントが空の場合はエラーとする
-		if strings.TrimSpace(req.Content) == "" {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Content is required : CommentID="+commentIDStr, nil))
+		// コメントのバリデーションを実施する
+		if err := validateCommentUpdateInput(req.Content, commentID); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		// コメントが500文字以上の場合はエラーとする
-		if len(req.Content) > MaxCommentLength {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Content must be 500 characters or less : CommentID="+commentIDStr, nil))
+		// コメントの更新を実施する
+		if err := commentService.UpdateComment(ctx, commentID, req.Content); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		// コメントの所有者か確認
-		var existringUserID, postID int
-		err = db.QueryRowContext(ctx, "SELECT user_id, post_id FROM comments WHERE id = $1", commentID).Scan(&existringUserID, &postID)
-		if err == sql.ErrNoRows {
-			respondAppError(w, apperror.NewAppError(apperror.TypeNotFound, "Comment not found : CommentID="+commentIDStr, err))
-			return
-		} else if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Database error : CommentID="+commentIDStr, err))
-			return
-		}
-		if existringUserID != userID {
-			respondAppError(w, apperror.NewAppError(apperror.TypeForbidden, "Forbidden : CommentID="+commentIDStr, nil))
-			return
-		}
-
-		// コメントの更新を実施
-		_, err = db.ExecContext(ctx, "UPDATE comments SET content = $1 WHERE id = $2", req.Content, commentID)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to update comment : CommentID="+commentIDStr, err))
-			return
-		}
-
-		w.WriteHeader(http.StatusOK)
-		if _, err := fmt.Fprintln(w, "Comment update successfully!"); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		// 更新成功をJSONで返す
+		respondJSON(w, http.StatusOK, map[string]string{"message": "Comment update successfully!"})
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "comment_updated", UserID: userID, PostID: postID})

--- a/internal/handler/likes.go
+++ b/internal/handler/likes.go
@@ -1,16 +1,10 @@
 package handler
 
 import (
-	"database/sql"
-	"encoding/json"
-	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/gorilla/mux"
-	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
-	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
-	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/service"
 	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
 )
 
@@ -22,47 +16,41 @@ import (
 // @Description - 無効なID → 400 Bad Request
 // @Description - リクエスト認証エラー → 401 Unauthorized
 // @Description - データ更新/取得失敗 or レスポンス書き込み失敗 → 500 ServerError
-// @Tags comments
+// @Tags likes
 // @Produce json
 // @Param id path int true "投稿ID"
-// @Success 201 {string} string "Post liked successfully"
+// @Success 201 {object} map[string]string
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/like [post]
-func LikePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func LikePostHandler(likeService *service.LikeService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// 認証情報からユーザーIDを取得
-		userID, ok := ctx.Value(middleware.UserIDKey).(int)
-		if !ok {
-			respondAppError(w, apperror.NewAppError(apperror.TypeUnauthorized, "Unauthorized : User ID not found in context", nil))
+		userID, appErr := userIDFromContext(ctx)
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// URIからpostのIDを取得
 		vars := mux.Vars(r)
-		postIDStr := vars["id"]
-		postID, err := strconv.Atoi(postIDStr)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid post ID : PostID="+postIDStr, nil))
+		postID, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// 「いいね」を登録する
-		_, err = db.ExecContext(ctx, "INSERT INTO likes (user_id, post_id) VALUES ($1, $2) ON CONFLICT DO NOTHING", userID, postID)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to like post : PostID="+postIDStr, err))
+		if err := likeService.LikePost(ctx, userID, postID); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		w.WriteHeader(http.StatusCreated)
-		if _, err := fmt.Fprintln(w, "Post liked successfully"); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		respondJSON(w, http.StatusCreated, map[string]string{"message": "Post liked successfully"})
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_liked", UserID: userID, PostID: postID})
@@ -76,63 +64,35 @@ func LikePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.Han
 // @Description **エラー条件:**
 // @Description - 無効なID → 400 Bad Request
 // @Description - データ更新/取得失敗 or レスポンス書き込み失敗 → 500 ServerError
-// @Tags comments
+// @Tags likes
 // @Produce json
 // @Param id path int true "投稿ID"
 // @Success 200 {object} models.LikesResponse
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/likes [get]
-func GetLikesHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func GetLikesHandler(likeService *service.LikeService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// URIからpostのIDを取得
 		vars := mux.Vars(r)
-		postIDStr := vars["id"]
-		postID, err := strconv.Atoi(postIDStr)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid post ID : PostID="+postIDStr, nil))
+		postID, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// 「いいね」の数とユーザー一覧を取得する
-		rows, err := db.QueryContext(ctx, "SELECT user_id FROM likes WHERE post_id = $1", postID)
+		likes, err := likeService.GetLikes(ctx, postID)
 		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to fetch likes : PostID="+postIDStr, err))
-			return
-		}
-		defer rows.Close()
-
-		// 「いいね」を押してくれたユーザーIDを保管する
-		var userIDs []int
-		for rows.Next() {
-			var userID int
-			if err := rows.Scan(&userID); err != nil {
-				respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to scan row : PostID="+postIDStr, err))
-				return
-			}
-			userIDs = append(userIDs, userID)
-		}
-
-		// rows.Next()のループが終了した後にエラーが発生していないか確認する(DBからのデータ取得中にエラーが発生していないか)
-		if err := rows.Err(); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to fetch likes : PostID="+postIDStr, err))
+			respondAppError(w, err)
 			return
 		}
 
 		// JSONレスポンスを返す
-		resp := models.LikesResponse{
-			PostID:    postID,
-			LikeCount: len(userIDs),
-			UserIDs:   userIDs,
-		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		respondJSON(w, http.StatusOK, likes)
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "likes_fetched", PostID: postID})
@@ -147,48 +107,43 @@ func GetLikesHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.Han
 // @Description - 無効なID → 400 Bad Request
 // @Description - リクエスト認証エラー → 401 Unauthorized
 // @Description - データ更新/取得失敗 or レスポンス書き込み失敗 → 500 ServerError
-// @Tags comments
+// @Tags likes
 // @Produce json
 // @Param id path int true "投稿ID"
-// @Success 204 {string} string "No Content"
+// @Success 204 "No Content"
 // @Failure 400 {object} models.ErrorResponse
 // @Failure 401 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/posts/{id}/like [delete]
-func UnlikePostHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func UnlikePostHandler(likeService *service.LikeService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
 
 		// 認証情報からユーザーIDを取得
-		userID, ok := ctx.Value(middleware.UserIDKey).(int)
-		if !ok {
-			respondAppError(w, apperror.NewAppError(apperror.TypeUnauthorized, "Unauthorized : User ID not found in context", nil))
+		userID, appErr := userIDFromContext(ctx)
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// URIからpostのIDを取得
 		vars := mux.Vars(r)
-		postIDStr := vars["id"]
-		postID, err := strconv.Atoi(postIDStr)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid post ID : PostID="+postIDStr, nil))
+		postID, appErr := parseID(vars["id"])
+		if appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
 		// 「いいね」を削除する
-		_, err = db.ExecContext(ctx, "DELETE FROM likes WHERE user_id = $1 AND post_id = $2", userID, postID)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to remove like : PostID="+postIDStr, err))
+		if err := likeService.UnlikePost(ctx, userID, postID); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		if _, err := fmt.Fprintln(w, "like removed successfully!"); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		respondJSON(w, http.StatusNoContent, nil)
+
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "post_unliked", UserID: userID, PostID: postID})
-		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/handler/request.go
+++ b/internal/handler/request.go
@@ -11,14 +11,19 @@ import (
 	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
 )
 
+// ID文字列を解析して数値に変換
+func parseID(idStr string) (int, *apperror.AppError) {
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return 0, apperror.NewAppError(apperror.TypeBadRequest, "Invalid id: "+idStr, err)
+	}
+	return id, nil
+}
+
 // URLから投稿IDを抽出する関数
 func postIDFromRequest(r *http.Request) (int, *apperror.AppError) {
 	idStr := strings.TrimPrefix(r.URL.Path, "/api/posts/")
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		return 0, apperror.NewAppError(apperror.TypeBadRequest, "Invalid ID : PostID="+idStr, err)
-	}
-	return id, nil
+	return parseID(idStr)
 }
 
 // コンテキストからユーザーIDを取得する関数

--- a/internal/handler/users.go
+++ b/internal/handler/users.go
@@ -1,17 +1,12 @@
 package handler
 
 import (
-	"database/sql"
-	"encoding/json"
 	"net/http"
-	"time"
 
-	"github.com/golang-jwt/jwt"
 	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
-	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
 	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/service"
 	"github.com/yusuke-hoguro/BlogApi/internal/workerpool"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // SignupHandler godoc
@@ -31,7 +26,7 @@ import (
 // @Failure 405 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/signup [post]
-func SignupHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func SignupHandler(userService *service.UserService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -44,43 +39,24 @@ func SignupHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.Handl
 
 		// GOの構造体にデコード
 		var userData models.User
-		err := json.NewDecoder(r.Body).Decode(&userData)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid request body", err))
+		if appErr := decodeJSON(r, &userData); appErr != nil {
+			respondAppError(w, appErr)
 			return
 		}
 
-		// ユーザー名が空の場合はエラーとする
-		if userData.Username == "" {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Username is required", nil))
+		// ユーザー登録のバリデーションを行う
+		if err := validateSignupInput(userData); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		// パスワードが8文字未満の場合はエラーとする
-		if len(userData.Password) < 8 {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Password must be at least 8 characters long", nil))
+		// ユーザー登録を実施する
+		if err := userService.Signup(ctx, &userData); err != nil {
+			respondAppError(w, err)
 			return
 		}
 
-		// パスワードをハッシュ化
-		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(userData.Password), bcrypt.DefaultCost)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to hash password : Username="+userData.Username, err))
-			return
-		}
-
-		// INSERT実行
-		err = db.QueryRowContext(ctx, "INSERT INTO users (username, password) VALUES ($1, $2) RETURNING id", userData.Username, string(hashedPassword)).Scan(&userData.ID)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to insert user : Username="+userData.Username, err))
-			return
-		}
-
-		w.WriteHeader(http.StatusCreated)
-		if err := json.NewEncoder(w).Encode(userData); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		respondJSON(w, http.StatusCreated, userData)
 
 		// 監視ワーカープールにイベントを追加
 		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "user_signed_up", UserID: userData.ID})
@@ -92,7 +68,7 @@ func SignupHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.Handl
 // @Description 送られてきたユーザー情報でログインする
 // @Description
 // @Description **エラー条件:**
-// @Description - 無効なユーザー情報、ユーザー名が空、パスワードが8文字未満 → 400 Bad Request
+// @Description - 無効なユーザー情報、ユーザー名が空、パスワードが空 → 400 Bad Request
 // @Description - ユーザー名かパスワードが不正 → 401 Unauthorized
 // @Description - 許可されていないメソッド → 405 MethodNotAllowed
 // @Description - データ更新/取得失敗、JWT生成失敗、レスポンス書き込み失敗 → 500 ServerError
@@ -106,7 +82,7 @@ func SignupHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.Handl
 // @Failure 405 {object} models.ErrorResponse
 // @Failure 500 {object} models.ErrorResponse
 // @Router /api/login [post]
-func LoginHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
+func LoginHandler(userService *service.UserService, auditPool *workerpool.AuditWorkerPool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// リクエストのコンテキストを取得する
 		ctx := r.Context()
@@ -119,78 +95,32 @@ func LoginHandler(db *sql.DB, auditPool *workerpool.AuditWorkerPool) http.Handle
 
 		// GOの構造体にデコード
 		var userData models.User
-		err := json.NewDecoder(r.Body).Decode(&userData)
+		if appErr := decodeJSON(r, &userData); appErr != nil {
+			respondAppError(w, appErr)
+			return
+		}
+
+		// ログインのバリデーションを行う
+		if err := validateLoginInput(userData); err != nil {
+			respondAppError(w, err)
+			return
+		}
+
+		// ログインを実施する
+		token, userID, err := userService.Login(ctx, userData)
 		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Invalid request body", err))
+			respondAppError(w, err)
 			return
 		}
 
-		// ユーザー名が空の場合はエラーとする
-		if userData.Username == "" {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Username is required", nil))
-			return
-		}
-
-		// パスワードが空の場合、エラーとする
-		if userData.Password == "" {
-			respondAppError(w, apperror.NewAppError(apperror.TypeBadRequest, "Password is required : Username="+userData.Username, nil))
-			return
-		}
-
-		// ユーザーをDBから検索
-		var id int
-		var hashedPassword string
-		err = db.QueryRowContext(ctx, "SELECT id, password FROM users WHERE username = $1", userData.Username).Scan(&id, &hashedPassword)
-		if err != nil {
-			if err == sql.ErrNoRows {
-				respondAppError(w, apperror.NewAppError(apperror.TypeUnauthorized, "Invalid username or password : Username="+userData.Username, err))
-			} else {
-				respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Database error : Username="+userData.Username, err))
-			}
-			return
-		}
-
-		// パスワード照合
-		err = bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(userData.Password))
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeUnauthorized, "Invalid username or password : Username="+userData.Username, err))
-			return
-		}
-
-		// JWT生成
-		token, err := GenerateJWT(id)
-		if err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to generate token : Username="+userData.Username, err))
-			return
-		}
-
-		// レスポンス
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(models.TokenResponse{Token: token}); err != nil {
-			respondAppError(w, apperror.NewAppError(apperror.TypeInternalServer, "Failed to write response", err))
-			return
-		}
+		respondJSON(w, http.StatusOK, models.TokenResponse{Token: token})
 
 		// 監視ワーカープールにイベントを追加
-		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "user_logged_in", UserID: id})
+		enqueueAuditEvent(ctx, auditPool, workerpool.AuditEvent{Action: "user_logged_in", UserID: userID})
 	}
 }
 
 // JWTトークンを発行する
 func GenerateJWT(userID int) (string, error) {
-	// payloadの生成
-	claims := &jwt.MapClaims{
-		"user_id": userID,
-		"exp":     time.Now().Add(24 * time.Hour).Unix(), // トークンの有効時間(24時間後)
-	}
-
-	// JWTを生成する
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	// 署名付きトークン生成
-	tokenString, err := token.SignedString(middleware.JwtKey)
-	if err != nil {
-		return "", err
-	}
-
-	return tokenString, nil
+	return service.GenerateJWT(userID)
 }

--- a/internal/handler/validation.go
+++ b/internal/handler/validation.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"strings"
 	"unicode/utf8"
 
@@ -12,6 +13,7 @@ import (
 const (
 	MaxTitleLength   = 100  // 投稿のタイトルの最大長
 	MaxContentLength = 1000 // 投稿の内容の最大長
+	MaxCommentLength = 500  // コメントの最大長
 )
 
 // 投稿の入力を検証する関数
@@ -35,5 +37,30 @@ func validatePostInput(post models.Post) *apperror.AppError {
 	if utf8.RuneCountInString(post.Content) > MaxContentLength {
 		return apperror.NewAppError(apperror.TypeBadRequest, "Content must be 1000 characters or less", nil)
 	}
+	return nil
+}
+
+// コメントの入力を検証する
+func validateCommentInput(comment models.Comment, postID int) *apperror.AppError {
+	return validateCommentContent(comment.Content, fmt.Sprintf("PostID=%d", postID))
+}
+
+// コメント更新の入力を検証する
+func validateCommentUpdateInput(content string, commentID int) *apperror.AppError {
+	return validateCommentContent(content, fmt.Sprintf("CommentID=%d", commentID))
+}
+
+// コメント本文を検証する
+func validateCommentContent(content string, target string) *apperror.AppError {
+	// コメントが空の場合はエラーとする
+	if strings.TrimSpace(content) == "" {
+		return apperror.NewAppError(apperror.TypeBadRequest, "Content is required : "+target, nil)
+	}
+
+	// コメントが指定文字以上の場合はエラーとする
+	if len(content) > MaxCommentLength {
+		return apperror.NewAppError(apperror.TypeBadRequest, fmt.Sprintf("Content must be %d characters or less : %s", MaxCommentLength, target), nil)
+	}
+
 	return nil
 }

--- a/internal/handler/validation.go
+++ b/internal/handler/validation.go
@@ -64,3 +64,33 @@ func validateCommentContent(content string, target string) *apperror.AppError {
 
 	return nil
 }
+
+// ユーザー登録の入力を検証する
+func validateSignupInput(user models.User) *apperror.AppError {
+	// ユーザー名が空の場合はエラーとする
+	if user.Username == "" {
+		return apperror.NewAppError(apperror.TypeBadRequest, "Username is required", nil)
+	}
+
+	// パスワードが8文字未満の場合はエラーとする
+	if len(user.Password) < 8 {
+		return apperror.NewAppError(apperror.TypeBadRequest, "Password must be at least 8 characters long", nil)
+	}
+
+	return nil
+}
+
+// ログインの入力を検証する
+func validateLoginInput(user models.User) *apperror.AppError {
+	// ユーザー名が空の場合はエラーとする
+	if user.Username == "" {
+		return apperror.NewAppError(apperror.TypeBadRequest, "Username is required", nil)
+	}
+
+	// パスワードが空の場合、エラーとする
+	if user.Password == "" {
+		return apperror.NewAppError(apperror.TypeBadRequest, "Password is required : Username="+user.Username, nil)
+	}
+
+	return nil
+}

--- a/internal/repository/comment_repository.go
+++ b/internal/repository/comment_repository.go
@@ -1,0 +1,115 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
+	"github.com/yusuke-hoguro/BlogApi/internal/models"
+)
+
+// コメント用のリポジトリ
+type CommentRepository struct {
+	db *sql.DB
+}
+
+// コメント用リポジトリのインスタンスを生成
+func NewCommentRepository(db *sql.DB) *CommentRepository {
+	return &CommentRepository{db: db}
+}
+
+// 指定した投稿IDのコメントを見つける
+func (r *CommentRepository) ListByPostID(ctx context.Context, postID int) ([]models.Comment, error) {
+	// 投稿IDを指定してコメントを取得する
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, post_id, user_id, content, created_at
+		FROM comments
+		WHERE post_id = $1
+		ORDER BY created_at ASC
+	`, postID)
+	if err != nil {
+		return nil, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to fetch comments : PostID=%d", postID), err)
+	}
+	defer rows.Close()
+
+	// 取得したコメントをスライスに格納(nilをJSON化しないようにスライスを初期化)
+	comments := []models.Comment{}
+	for rows.Next() {
+		var c models.Comment
+		if err := rows.Scan(&c.ID, &c.PostID, &c.UserID, &c.Content, &c.CreatedAt); err != nil {
+			return nil, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Error reading comment : PostID=%d", postID), err)
+		}
+		comments = append(comments, c)
+	}
+
+	// rows.Next()のループが終了した後にエラーが発生していないか確認する(DBからのデータ取得中にエラーが発生していないか)
+	if err := rows.Err(); err != nil {
+		return nil, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to fetch comments : PostID=%d", postID), err)
+	}
+
+	return comments, nil
+}
+
+// 指定したIDのコメントを見つける(存在しない場合はnilを返したいのでポインタを返す)
+func (r *CommentRepository) FindByID(ctx context.Context, id int) (*models.Comment, error) {
+	// 指定したIDのコメントを取得する
+	var comment models.Comment
+	err := r.db.QueryRowContext(ctx, "SELECT id, post_id, user_id, content, created_at FROM comments WHERE id = $1", id).Scan(&comment.ID, &comment.PostID, &comment.UserID, &comment.Content, &comment.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, apperror.NewAppError(apperror.TypeNotFound, fmt.Sprintf("Comment Not Found : CommentID=%d", id), err)
+	} else if err != nil {
+		return nil, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Database error : CommentID=%d", id), err)
+	}
+	return &comment, nil
+}
+
+// コメントを作成する
+func (r *CommentRepository) Create(ctx context.Context, comment *models.Comment) error {
+	// コメントを挿入する
+	query := `INSERT INTO comments (post_id, user_id, content) 
+				VALUES ($1, $2, $3)
+				RETURNING id, post_id, user_id, content, created_at`
+
+	err := r.db.QueryRowContext(ctx, query, comment.PostID, comment.UserID, comment.Content).Scan(
+		&comment.ID,
+		&comment.PostID,
+		&comment.UserID,
+		&comment.Content,
+		&comment.CreatedAt,
+	)
+	if err != nil {
+		return apperror.NewAppError(apperror.TypeInternalServer, "Failed to insert comment", err)
+	}
+	return nil
+}
+
+// 指定したコメントIDから所有者のユーザーIDと投稿IDを取得する
+func (r *CommentRepository) FindOwnerByID(ctx context.Context, commentID int) (int, int, error) {
+	var userID, postID int
+	err := r.db.QueryRowContext(ctx, "SELECT user_id, post_id FROM comments WHERE id = $1", commentID).Scan(&userID, &postID)
+	if err == sql.ErrNoRows {
+		return 0, 0, apperror.NewAppError(apperror.TypeNotFound, fmt.Sprintf("Comment not found : CommentID=%d", commentID), err)
+	} else if err != nil {
+		return 0, 0, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Database error : CommentID=%d", commentID), err)
+	}
+	return userID, postID, nil
+}
+
+// 指定したIDのコメントを削除する
+func (r *CommentRepository) Delete(ctx context.Context, commentID int) error {
+	result, err := r.db.ExecContext(ctx, "DELETE FROM comments WHERE id = $1", commentID)
+	if err != nil {
+		return apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to delete comment : CommentID=%d", commentID), err)
+	}
+	return checkRowAffected(result, fmt.Sprintf("Comment not found : CommentID=%d", commentID))
+}
+
+// 指定したIDのコメントを更新する
+func (r *CommentRepository) Update(ctx context.Context, commentID int, content string) error {
+	result, err := r.db.ExecContext(ctx, "UPDATE comments SET content = $1 WHERE id = $2", content, commentID)
+	if err != nil {
+		return apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to update comment : CommentID=%d", commentID), err)
+	}
+	return checkRowAffected(result, fmt.Sprintf("Comment not found : CommentID=%d", commentID))
+}

--- a/internal/repository/db_executor.go
+++ b/internal/repository/db_executor.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DBExecutor は sql.DB / sql.Tx の共通DB操作を表す。
+type DBExecutor interface {
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}

--- a/internal/repository/like_repository.go
+++ b/internal/repository/like_repository.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
+)
+
+// いいね用のリポジトリ
+type LikeRepository struct {
+	db DBExecutor
+}
+
+// いいね用リポジトリのインスタンスを生成
+func NewLikeRepository(db DBExecutor) *LikeRepository {
+	return &LikeRepository{db: db}
+}
+
+// 投稿にいいねを追加する
+func (r *LikeRepository) Create(ctx context.Context, userID int, postID int) error {
+	_, err := r.db.ExecContext(ctx, "INSERT INTO likes (user_id, post_id) VALUES ($1, $2) ON CONFLICT DO NOTHING", userID, postID)
+	if err != nil {
+		return apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to like post : PostID=%d", postID), err)
+	}
+	return nil
+}
+
+// 投稿のいいねを削除する
+func (r *LikeRepository) Delete(ctx context.Context, userID int, postID int) error {
+	_, err := r.db.ExecContext(ctx, "DELETE FROM likes WHERE user_id = $1 AND post_id = $2", userID, postID)
+	if err != nil {
+		return apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to remove like : PostID=%d", postID), err)
+	}
+	return nil
+}
+
+// 指定した投稿のいいねユーザーID一覧を取得する
+func (r *LikeRepository) ListUserIDsByPostID(ctx context.Context, postID int) ([]int, error) {
+	rows, err := r.db.QueryContext(ctx, "SELECT user_id FROM likes WHERE post_id = $1", postID)
+	if err != nil {
+		return nil, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to fetch likes : PostID=%d", postID), err)
+	}
+	defer rows.Close()
+
+	userIDs := []int{}
+	for rows.Next() {
+		var userID int
+		if err := rows.Scan(&userID); err != nil {
+			return nil, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to scan row : PostID=%d", postID), err)
+		}
+		userIDs = append(userIDs, userID)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, apperror.NewAppError(apperror.TypeInternalServer, fmt.Sprintf("Failed to fetch likes : PostID=%d", postID), err)
+	}
+
+	return userIDs, nil
+}

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
+)
+
+// ユーザー用のリポジトリ
+type UserRepository struct {
+	db DBExecutor
+}
+
+// ユーザー用リポジトリのインスタンスを生成
+func NewUserRepository(db DBExecutor) *UserRepository {
+	return &UserRepository{db: db}
+}
+
+// ユーザーを作成する
+func (r *UserRepository) Create(ctx context.Context, username string, hashedPassword string) (int, error) {
+	var id int
+	err := r.db.QueryRowContext(ctx, "INSERT INTO users (username, password) VALUES ($1, $2) RETURNING id", username, hashedPassword).Scan(&id)
+	if err != nil {
+		return 0, apperror.NewAppError(apperror.TypeInternalServer, "Failed to insert user : Username="+username, err)
+	}
+	return id, nil
+}
+
+// ユーザー名から認証情報を取得する
+func (r *UserRepository) FindAuthByUsername(ctx context.Context, username string) (int, string, error) {
+	var id int
+	var hashedPassword string
+	err := r.db.QueryRowContext(ctx, "SELECT id, password FROM users WHERE username = $1", username).Scan(&id, &hashedPassword)
+	if err == sql.ErrNoRows {
+		return 0, "", apperror.NewAppError(apperror.TypeUnauthorized, "Invalid username or password : Username="+username, err)
+	} else if err != nil {
+		return 0, "", apperror.NewAppError(apperror.TypeInternalServer, "Database error : Username="+username, err)
+	}
+	return id, hashedPassword, nil
+}

--- a/internal/router/routers.go
+++ b/internal/router/routers.go
@@ -31,11 +31,11 @@ func RegisterRoutes(r *mux.Router, db *sql.DB, auditPool *workerpool.AuditWorker
 	r.HandleFunc("/api/signup", handler.SignupHandler(db, auditPool)).Methods(http.MethodPost) // ユーザー登録用
 	r.HandleFunc("/api/login", handler.LoginHandler(db, auditPool)).Methods(http.MethodPost)   // ログイン用
 	// コメント関係
-	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db, auditPool)).Methods(http.MethodGet)                     // 投稿のコメント取得
-	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db, auditPool))).Methods(http.MethodPost) // 投稿のコメント投稿
-	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(db, auditPool)).Methods(http.MethodGet)                               // コメントIDで詳細取得
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db, auditPool))).Methods(http.MethodDelete)   // コメントIDで削除
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db, auditPool))).Methods(http.MethodPut)      // コメントを更新する
+	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(services.Comment, auditPool)).Methods(http.MethodGet)                     // 投稿のコメント取得
+	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(services.Comment, auditPool))).Methods(http.MethodPost) // 投稿のコメント投稿
+	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(services.Comment, auditPool)).Methods(http.MethodGet)                               // コメントIDで詳細取得
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(services.Comment, auditPool))).Methods(http.MethodDelete)   // コメントIDで削除
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(services.Comment, auditPool))).Methods(http.MethodPut)      // コメントを更新する
 	// 「いいね」関係
 	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db, auditPool))).Methods(http.MethodPost)     // 投稿にいいねをつける
 	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db, auditPool)).Methods(http.MethodGet)                                // 投稿のいいねを取得する

--- a/internal/router/routers.go
+++ b/internal/router/routers.go
@@ -37,7 +37,7 @@ func RegisterRoutes(r *mux.Router, db *sql.DB, auditPool *workerpool.AuditWorker
 	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(services.Comment, auditPool))).Methods(http.MethodDelete)   // コメントIDで削除
 	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(services.Comment, auditPool))).Methods(http.MethodPut)      // コメントを更新する
 	// 「いいね」関係
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db, auditPool))).Methods(http.MethodPost)     // 投稿にいいねをつける
-	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db, auditPool)).Methods(http.MethodGet)                                // 投稿のいいねを取得する
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db, auditPool))).Methods(http.MethodDelete) // 投稿のいいねを削除する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(services.Like, auditPool))).Methods(http.MethodPost)     // 投稿にいいねをつける
+	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(services.Like, auditPool)).Methods(http.MethodGet)                                // 投稿のいいねを取得する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(services.Like, auditPool))).Methods(http.MethodDelete) // 投稿のいいねを削除する
 }

--- a/internal/router/routers.go
+++ b/internal/router/routers.go
@@ -28,8 +28,8 @@ func RegisterRoutes(r *mux.Router, db *sql.DB, auditPool *workerpool.AuditWorker
 	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(services.Post, auditPool))).Methods(http.MethodDelete) // 個別投稿削除用
 	r.HandleFunc("/api/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(services.Post, auditPool))).Methods(http.MethodGet)       // 自身の投稿のみ取得
 	// ユーザー認証系
-	r.HandleFunc("/api/signup", handler.SignupHandler(db, auditPool)).Methods(http.MethodPost) // ユーザー登録用
-	r.HandleFunc("/api/login", handler.LoginHandler(db, auditPool)).Methods(http.MethodPost)   // ログイン用
+	r.HandleFunc("/api/signup", handler.SignupHandler(services.User, auditPool)).Methods(http.MethodPost) // ユーザー登録用
+	r.HandleFunc("/api/login", handler.LoginHandler(services.User, auditPool)).Methods(http.MethodPost)   // ログイン用
 	// コメント関係
 	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(services.Comment, auditPool)).Methods(http.MethodGet)                     // 投稿のコメント取得
 	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(services.Comment, auditPool))).Methods(http.MethodPost) // 投稿のコメント投稿

--- a/internal/service/comment_service.go
+++ b/internal/service/comment_service.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
+	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/repository"
+)
+
+// コメント用サービスの構造体
+type CommentService struct {
+	repo *repository.CommentRepository
+}
+
+// コメント用サービスのインスタンスを生成する関数
+func NewCommentService(repo *repository.CommentRepository) *CommentService {
+	return &CommentService{repo: repo}
+}
+
+// 指定した投稿IDのコメントを取得する
+func (s *CommentService) GetCommentsByPostID(ctx context.Context, postID int) ([]models.Comment, error) {
+	return s.repo.ListByPostID(ctx, postID)
+}
+
+// 指定したIDのコメントを取得する
+func (s *CommentService) GetCommentByID(ctx context.Context, commentID int) (*models.Comment, error) {
+	return s.repo.FindByID(ctx, commentID)
+}
+
+// コメントの作成処理を実施する
+func (s *CommentService) CreateComment(ctx context.Context, postID int, userID int, comment *models.Comment) error {
+	comment.PostID = postID
+	comment.UserID = userID
+	return s.repo.Create(ctx, comment)
+}
+
+// リクエストのユーザーとコメント所有者を確認する
+func (s *CommentService) EnsureCommentOwner(ctx context.Context, userID int, commentID int) (int, error) {
+	commentOwnerID, postID, err := s.repo.FindOwnerByID(ctx, commentID)
+	if err != nil {
+		return 0, err
+	}
+	if commentOwnerID != userID {
+		return 0, apperror.NewAppError(apperror.TypeForbidden, fmt.Sprintf("Forbidden : CommentID=%d", commentID), nil)
+	}
+	return postID, nil
+}
+
+// コメントの削除処理を実施する
+func (s *CommentService) DeleteComment(ctx context.Context, commentID int) error {
+	return s.repo.Delete(ctx, commentID)
+}
+
+// コメントの更新処理を実施する
+func (s *CommentService) UpdateComment(ctx context.Context, commentID int, content string) error {
+	return s.repo.Update(ctx, commentID, content)
+}

--- a/internal/service/like_service.go
+++ b/internal/service/like_service.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"context"
+
+	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/repository"
+)
+
+// いいね用サービスの構造体
+type LikeService struct {
+	repo *repository.LikeRepository
+}
+
+// いいね用サービスのインスタンスを生成する関数
+func NewLikeService(repo *repository.LikeRepository) *LikeService {
+	return &LikeService{repo: repo}
+}
+
+// 投稿にいいねを追加する
+func (s *LikeService) LikePost(ctx context.Context, userID int, postID int) error {
+	return s.repo.Create(ctx, userID, postID)
+}
+
+// 投稿のいいねを削除する
+func (s *LikeService) UnlikePost(ctx context.Context, userID int, postID int) error {
+	return s.repo.Delete(ctx, userID, postID)
+}
+
+// 投稿のいいね情報を取得する
+func (s *LikeService) GetLikes(ctx context.Context, postID int) (*models.LikesResponse, error) {
+	userIDs, err := s.repo.ListUserIDsByPostID(ctx, postID)
+	if err != nil {
+		return nil, err
+	}
+	return &models.LikesResponse{
+		PostID:    postID,
+		LikeCount: len(userIDs),
+		UserIDs:   userIDs,
+	}, nil
+}

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/golang-jwt/jwt"
+	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
+	"github.com/yusuke-hoguro/BlogApi/internal/middleware"
+	"github.com/yusuke-hoguro/BlogApi/internal/models"
+	"github.com/yusuke-hoguro/BlogApi/internal/repository"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ユーザー用サービスの構造体
+type UserService struct {
+	repo *repository.UserRepository
+}
+
+// ユーザー用サービスのインスタンスを生成する関数
+func NewUserService(repo *repository.UserRepository) *UserService {
+	return &UserService{repo: repo}
+}
+
+// ユーザー登録を実施する
+func (s *UserService) Signup(ctx context.Context, user *models.User) error {
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return apperror.NewAppError(apperror.TypeInternalServer, "Failed to hash password : Username="+user.Username, err)
+	}
+
+	id, err := s.repo.Create(ctx, user.Username, string(hashedPassword))
+	if err != nil {
+		return err
+	}
+	user.ID = id
+	return nil
+}
+
+// ログインを実施する
+func (s *UserService) Login(ctx context.Context, user models.User) (string, int, error) {
+	id, hashedPassword, err := s.repo.FindAuthByUsername(ctx, user.Username)
+	if err != nil {
+		return "", 0, err
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(user.Password)); err != nil {
+		return "", 0, apperror.NewAppError(apperror.TypeUnauthorized, "Invalid username or password : Username="+user.Username, err)
+	}
+
+	token, err := GenerateJWT(id)
+	if err != nil {
+		return "", 0, apperror.NewAppError(apperror.TypeInternalServer, "Failed to generate token : Username="+user.Username, err)
+	}
+
+	return token, id, nil
+}
+
+// JWTトークンを発行する
+func GenerateJWT(userID int) (string, error) {
+	// payloadの生成
+	claims := &jwt.MapClaims{
+		"user_id": userID,
+		"exp":     time.Now().Add(24 * time.Hour).Unix(),
+	}
+
+	// JWTを生成する
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	// 署名付きトークン生成
+	return token.SignedString(middleware.JwtKey)
+}

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -78,23 +78,23 @@ func SetupTestServer(db *sql.DB) (http.Handler, func()) {
 	cleanup := func() {
 		auditPool.Stop()
 	}
-	r.HandleFunc("/api/healthz", handler.HealthzHandler(auditPool)).Methods(http.MethodGet, http.MethodHead)                          // ヘルスチェック用
-	r.HandleFunc("/api/posts", handler.GetAllPostsHandler(services.Post, auditPool)).Methods("GET")                                   // 全投稿取得用
-	r.HandleFunc("/api/posts/{id}", handler.GetPostsByIDHandler(services.Post, auditPool)).Methods("GET")                             // 個別投稿取得用
-	r.HandleFunc("/api/posts", middleware.AuthMiddleware(handler.CreatePostHandler(services.Post, auditPool))).Methods("POST")        // 個別投稿作成用
-	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(services.Post, auditPool))).Methods("PUT")    // 個別投稿更新用
-	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(services.Post, auditPool))).Methods("DELETE") // 個別投稿削除用
-	r.HandleFunc("/api/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(services.Post, auditPool))).Methods("GET")       // 自身の投稿のみ取得
-	r.HandleFunc("/api/signup", handler.SignupHandler(db, auditPool)).Methods("POST")                                                 // ユーザー登録用
-	r.HandleFunc("/api/login", handler.LoginHandler(db, auditPool)).Methods("POST")                                                   // ログイン用
-	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(db, auditPool))).Methods("POST")    // コメント投稿
-	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(db, auditPool)).Methods("GET")                        // 投稿のコメント取得
-	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(db, auditPool)).Methods("GET")                                  // コメントIDで詳細取得
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(db, auditPool))).Methods("DELETE")      // コメントIDで削除
-	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(db, auditPool))).Methods("PUT")         // コメントを更新する
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db, auditPool))).Methods("POST")           // 投稿にいいねをつける
-	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db, auditPool)).Methods("GET")                                      // 投稿のいいねを取得する
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db, auditPool))).Methods("DELETE")       // 投稿のいいねを削除する
+	r.HandleFunc("/api/healthz", handler.HealthzHandler(auditPool)).Methods(http.MethodGet, http.MethodHead)                                     // ヘルスチェック用
+	r.HandleFunc("/api/posts", handler.GetAllPostsHandler(services.Post, auditPool)).Methods("GET")                                              // 全投稿取得用
+	r.HandleFunc("/api/posts/{id}", handler.GetPostsByIDHandler(services.Post, auditPool)).Methods("GET")                                        // 個別投稿取得用
+	r.HandleFunc("/api/posts", middleware.AuthMiddleware(handler.CreatePostHandler(services.Post, auditPool))).Methods("POST")                   // 個別投稿作成用
+	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(services.Post, auditPool))).Methods("PUT")               // 個別投稿更新用
+	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(services.Post, auditPool))).Methods("DELETE")            // 個別投稿削除用
+	r.HandleFunc("/api/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(services.Post, auditPool))).Methods("GET")                  // 自身の投稿のみ取得
+	r.HandleFunc("/api/signup", handler.SignupHandler(db, auditPool)).Methods("POST")                                                            // ユーザー登録用
+	r.HandleFunc("/api/login", handler.LoginHandler(db, auditPool)).Methods("POST")                                                              // ログイン用
+	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(services.Comment, auditPool))).Methods("POST") // コメント投稿
+	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(services.Comment, auditPool)).Methods("GET")                     // 投稿のコメント取得
+	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(services.Comment, auditPool)).Methods("GET")                               // コメントIDで詳細取得
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(services.Comment, auditPool))).Methods("DELETE")   // コメントIDで削除
+	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(services.Comment, auditPool))).Methods("PUT")      // コメントを更新する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db, auditPool))).Methods("POST")                      // 投稿にいいねをつける
+	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db, auditPool)).Methods("GET")                                                 // 投稿のいいねを取得する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db, auditPool))).Methods("DELETE")                  // 投稿のいいねを削除する
 	return r, cleanup
 }
 

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -85,8 +85,8 @@ func SetupTestServer(db *sql.DB) (http.Handler, func()) {
 	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.UpdatePostHandler(services.Post, auditPool))).Methods("PUT")               // 個別投稿更新用
 	r.HandleFunc("/api/posts/{id}", middleware.AuthMiddleware(handler.DeletePostHandler(services.Post, auditPool))).Methods("DELETE")            // 個別投稿削除用
 	r.HandleFunc("/api/myposts", middleware.AuthMiddleware(handler.GetMyPostsHandler(services.Post, auditPool))).Methods("GET")                  // 自身の投稿のみ取得
-	r.HandleFunc("/api/signup", handler.SignupHandler(db, auditPool)).Methods("POST")                                                            // ユーザー登録用
-	r.HandleFunc("/api/login", handler.LoginHandler(db, auditPool)).Methods("POST")                                                              // ログイン用
+	r.HandleFunc("/api/signup", handler.SignupHandler(services.User, auditPool)).Methods("POST")                                                 // ユーザー登録用
+	r.HandleFunc("/api/login", handler.LoginHandler(services.User, auditPool)).Methods("POST")                                                   // ログイン用
 	r.HandleFunc("/api/posts/{id}/comments", middleware.AuthMiddleware(handler.PostCommentHandler(services.Comment, auditPool))).Methods("POST") // コメント投稿
 	r.HandleFunc("/api/posts/{id}/comments", handler.GetCommentsByPostIDHandler(services.Comment, auditPool)).Methods("GET")                     // 投稿のコメント取得
 	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(services.Comment, auditPool)).Methods("GET")                               // コメントIDで詳細取得

--- a/testutils/setup.go
+++ b/testutils/setup.go
@@ -92,9 +92,9 @@ func SetupTestServer(db *sql.DB) (http.Handler, func()) {
 	r.HandleFunc("/api/comments/{id}", handler.GetCommentsByIDHandler(services.Comment, auditPool)).Methods("GET")                               // コメントIDで詳細取得
 	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.DeleteCommentHandler(services.Comment, auditPool))).Methods("DELETE")   // コメントIDで削除
 	r.HandleFunc("/api/comments/{id}", middleware.AuthMiddleware(handler.UpdateCommentHandler(services.Comment, auditPool))).Methods("PUT")      // コメントを更新する
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(db, auditPool))).Methods("POST")                      // 投稿にいいねをつける
-	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(db, auditPool)).Methods("GET")                                                 // 投稿のいいねを取得する
-	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(db, auditPool))).Methods("DELETE")                  // 投稿のいいねを削除する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.LikePostHandler(services.Like, auditPool))).Methods("POST")           // 投稿にいいねをつける
+	r.HandleFunc("/api/posts/{id}/likes", handler.GetLikesHandler(services.Like, auditPool)).Methods("GET")                                      // 投稿のいいねを取得する
+	r.HandleFunc("/api/posts/{id}/like", middleware.AuthMiddleware(handler.UnlikePostHandler(services.Like, auditPool))).Methods("DELETE")       // 投稿のいいねを削除する
 	return r, cleanup
 }
 


### PR DESCRIPTION
## 作業のチケット番号
<!-- 関連するチケット番号があれば記載 -->
なし

## 概要
<!-- 変更内容の簡単な説明を記述 -->
ハンドラー関数に集中していたDB操作、ユースケース処理、入力検証、レスポンス生成の責務を整理し、主要APIをservice/repository層へ分離しました。

## 設計書
<!-- 必要に応じて追加情報を記述 -->
- `handler -> service -> repository -> DB` の依存方向に整理
- `internal/app.Services` で各serviceの依存関係をまとめて生成
- handlerはHTTPリクエストの読み取り、入力検証、service呼び出し、レスポンス返却を主な責務に限定
- repositoryはSQL実行とDB結果のモデル変換を担当
- serviceはユースケース処理、認可確認、パスワード照合、JWT生成などを担当

## 変更内容
<!-- 具体的な変更点のリストを記述 -->
- コメント関連ハンドラーを `CommentService` / `CommentRepository` に分離
  - コメント一覧取得、コメント詳細取得、コメント作成、更新、削除をservice/repository経由に変更
- いいね関連ハンドラーを `LikeService` / `LikeRepository` に分離
  - いいね追加、取得、削除をservice/repository経由に変更
- ユーザー関連ハンドラーを `UserService` / `UserRepository` に分離
  - ユーザー登録、ログイン、パスワードハッシュ化、パスワード照合、JWT生成を整理
- `internal/app.Services` に `Comment` / `Like` / `User` serviceを追加
- `router` と `testutils` で各handlerへserviceインスタンスを渡すよう変更
- 共通処理を整理
  - JSONレスポンス返却
  - IDパース
  - JSON decode
  - 投稿/コメント/ユーザー入力バリデーション
- Swaggerコメントを実装挙動に合わせて調整

## テスト方法
<!-- テスト方法を記述 -->
- `gofmt` 実行済み
- `go test ./...` はローカルWSL環境で `go` コマンドが見つからず未実行

## チェックリスト
<!-- 必要に応じて追加情報を記述 -->
- [x] ビルド成功
- [x] 自動テスト成功
- [x] リファクタリング
- [x] コメントは適切である
- [x] 不要なSleepは設けていない