### PR TITLE
重複ユーザー作成時に409を返すよう修正

### DIFF
--- a/internal/handler/users_test.go
+++ b/internal/handler/users_test.go
@@ -1,0 +1,43 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/yusuke-hoguro/BlogApi/testutils"
+)
+
+// ユーザー登録用APIの重複ユーザー確認テスト
+func TestSignupHandlerDuplicateUsername(t *testing.T) {
+	// テスト用DBのセットアップを開始する
+	db := testutils.SetupTestDB(t)
+	defer db.Close()
+
+	// テスト用サーバーのセットアップ
+	h, cleanup := testutils.SetupTestServer(db)
+	server := httptest.NewServer(h)
+	defer server.Close()
+	defer cleanup()
+
+	// testdata/init_test.sql で作成済みのユーザー名を指定する
+	signupJSON := `{"username":"testuser","password":"password123"}`
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/signup", strings.NewReader(signupJSON))
+	if err != nil {
+		t.Fatal("リクエスト生成失敗:", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// リクエスト送信
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatal("HTTPリクエスト失敗:", err)
+	}
+	defer resp.Body.Close()
+
+	// ステータスコード確認
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("期待するステータスコード %d, 実際は %d", http.StatusConflict, resp.StatusCode)
+	}
+}

--- a/internal/handler/users_test.go
+++ b/internal/handler/users_test.go
@@ -22,7 +22,7 @@ func TestSignupHandlerDuplicateUsername(t *testing.T) {
 	defer cleanup()
 
 	// testdata/init_test.sql で作成済みのユーザー名を指定する
-	signupJSON := `{"username":"testuser","password":"password123"}`
+	signupJSON := `{"username":"testuser","password":"password"}`
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/signup", strings.NewReader(signupJSON))
 	if err != nil {
 		t.Fatal("リクエスト生成失敗:", err)

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -3,7 +3,9 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 
+	"github.com/lib/pq"
 	"github.com/yusuke-hoguro/BlogApi/internal/apperror"
 )
 
@@ -22,6 +24,9 @@ func (r *UserRepository) Create(ctx context.Context, username string, hashedPass
 	var id int
 	err := r.db.QueryRowContext(ctx, "INSERT INTO users (username, password) VALUES ($1, $2) RETURNING id", username, hashedPassword).Scan(&id)
 	if err != nil {
+		if isUniqueViolation(err, "users_username_key") {
+			return 0, apperror.NewAppError(apperror.TypeConflict, "User already exists : Username="+username, err)
+		}
 		return 0, apperror.NewAppError(apperror.TypeInternalServer, "Failed to insert user : Username="+username, err)
 	}
 	return id, nil
@@ -38,4 +43,9 @@ func (r *UserRepository) FindAuthByUsername(ctx context.Context, username string
 		return 0, "", apperror.NewAppError(apperror.TypeInternalServer, "Database error : Username="+username, err)
 	}
 	return id, hashedPassword, nil
+}
+
+func isUniqueViolation(err error, constraint string) bool {
+	var pqErr *pq.Error
+	return errors.As(err, &pqErr) && string(pqErr.Code) == "23505" && pqErr.Constraint == constraint
 }

--- a/testdata/init_test.sql
+++ b/testdata/init_test.sql
@@ -52,23 +52,31 @@ CREATE TABLE IF NOT EXISTS post_stats(
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- 初期データ投入
+-- 初期データ投入、投入後にシーケンスの値を更新する
 INSERT INTO posts (user_id, title, content) VALUES
   (1, 'テストタイトル1', 'テスト内容1'),
   (2, 'テストタイトル2', 'テスト内容2'),
   (3, 'コメントテスト用', 'コメント追加テスト');
 
+SELECT setval(pg_get_serial_sequence('posts', 'id'), (SELECT MAX(id) FROM posts));
+
 INSERT INTO users (id, username, password) VALUES
-  (1, 'testuser', 'pass'),
-  (2, 'testuser2', 'pass2'),
-  (3, 'testuser3', 'pass3');
+  (1, 'testuser', 'password'),
+  (2, 'testuser2', 'password2'),
+  (3, 'testuser3', 'password3');
+
+SELECT setval(pg_get_serial_sequence('users', 'id'), (SELECT MAX(id) FROM users));
 
 INSERT INTO comments (id, post_id, user_id, content) VALUES
   (3, 1, 1, 'Default Comment'),
   (4, 1, 1, 'Default Comment'),
   (2, 2, 2, 'Delete Comment');
 
+SELECT setval(pg_get_serial_sequence('comments', 'id'), (SELECT MAX(id) FROM comments));
+
 INSERT INTO likes (id, user_id, post_id) VALUES
   (1, 1, 1),
   (2, 2, 1),
   (3, 3, 1);
+
+SELECT setval(pg_get_serial_sequence('likes', 'id'), (SELECT MAX(id) FROM likes));


### PR DESCRIPTION
## 作業のチケット番号
<!-- 関連するチケット番号があれば記載 -->
なし

## 概要
<!-- 変更内容の簡単な説明を記述 -->
ユーザー作成時に既存のユーザー名が指定された場合、PostgreSQL の UNIQUE 制約違反を検出して `409 Conflict` を返すように修正しました。

また、テストデータで ID を手動投入した後に PostgreSQL のシーケンスが進まず、次回 INSERT 時に主キー重複が発生する問題を修正しました。

## 設計書
<!-- 必要に応じて追加情報を記述 -->
なし

## 変更内容
<!-- 具体的な変更点のリストを記述 -->
- `users.username` の UNIQUE 制約違反を `apperror.TypeConflict` に変換
- `/api/signup` で既存ユーザー名を登録した場合に `409 Conflict` になる handler テストを追加
- `testdata/init_test.sql` で初期データ投入後に各テーブルのシーケンスを更新

## テスト方法
<!-- テスト方法を記述 -->
- ローカル環境で手動で実施
- PR時にGitHub Actionsで確認

## チェックリスト
<!-- 必要に応じて追加情報を記述 -->
- [x] ビルド成功
- [x] 自動テスト成功
- [x] リファクタリング
- [x] コメントは適切である
- [x] 不要なSleepは設けていない