### PR TITLE
GitHub ActionsのStepsを並列化してCI時間を短縮

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -53,12 +53,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Verify dependencies
-        run: go mod tidy && git diff --exit-code go.mod go.sum 
+      # 依存関係の検証とDocker Composeによるテストを並列で実行する
+      - parallel:
+          - name: Verify dependencies
+            run: go mod tidy -diff
 
-      # Docker Composeでビルドとテスト実行
-      - name: Build and run tests (docker-compose)
-        run: docker compose -f ./infra/docker-compose.test.yml --env-file ./.env up --build --abort-on-container-exit || exit 1
+          # Docker Composeでビルドとテスト実行
+          - name: Build and run tests (docker-compose)
+            run: docker compose -f ./infra/docker-compose.test.yml --env-file ./.env up --build --abort-on-container-exit || exit 1
 
       # カバレッジ対応
       - name: Upload coverage report
@@ -86,6 +88,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Cleanup
+        if: always()
         run:  docker compose -f ./infra/docker-compose.test.yml --env-file ./.env down -v
   
   generate-swagger:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,25 +32,29 @@ jobs:
           cache: "npm"
           cache-dependency-path: blog-api-frontend/package-lock.json
       
-      # 依存するライブラリをインストールする
-      - name: Install frontend dependencies
-        working-directory: blog-api-frontend
-        run: npm ci
+      # フロントエンド依存関係のインストールとBlogAPIのビルド・起動を並列で実行する
+      - parallel:
+          # 依存するライブラリをインストールする
+          - name: Install frontend dependencies
+            working-directory: blog-api-frontend
+            run: npm ci
 
-      # Playwrightのブラウザとライブラリをインストールする(--with-depsdeでOS側の依存ライブラリを検出してインストール)
-      - name: Install playwright browsers
-        working-directory: blog-api-frontend
-        run: npx playwright install --with-deps
+          # BlogAPIを起動する
+          - name: Start BlogApi
+            run: docker compose --env-file ./.env -f ./infra/docker-compose.yml up -d --build
 
-      # BlogAPIを起動する
-      - name: Start BlogApi
-        run: docker compose --env-file ./.env -f ./infra/docker-compose.yml up -d --build
+      # PlaywrightブラウザのインストールとBlogAPIの起動待機を並列で実行する
+      - parallel:
+          # Playwrightのブラウザとライブラリをインストールする(--with-depsdeでOS側の依存ライブラリを検出してインストール)
+          - name: Install playwright browsers
+            working-directory: blog-api-frontend
+            run: npx playwright install --with-deps
 
-      # BlogAPIの起動を待機する
-      - name: Wait for BlogAPI to start
-        run: |
-          npx wait-on http://localhost:3000 --timeout 120000
-          npx wait-on http://localhost:8080/api/healthz --timeout 120000
+          # BlogAPIの起動を待機する
+          - name: Wait for BlogAPI to start
+            run: |
+              npx wait-on http://localhost:3000 --timeout 120000
+              npx wait-on http://localhost:8080/api/healthz --timeout 120000
 
       # Playwrightのテストを実行する
       - name: Run playwright tests


### PR DESCRIPTION
## 作業のチケット番号
なし

## 概要
GitHub ActionsのSteps並列実行を導入し、BackendテストとE2EテストのCI実行時間を短縮します。

## 設計書
なし

## 変更内容
- E2E workflowで、フロントエンド依存関係のインストールとBlogAPIのビルド・起動を並列化
- E2E workflowで、PlaywrightブラウザのインストールとBlogAPIの起動待機を並列化
- Backend workflowで、Go依存関係の検証とDocker Composeによるテストを並列化
- Go依存関係の検証を、ファイルを変更しない`go mod tidy -diff`へ変更
- Backendテストのcleanupを、失敗時も実行するように変更

## テスト方法
GitHub Actionsを実行し、Backend TestsとE2E Testsが正常終了することを確認しました。

## チェックリスト
- [x] ビルド成功
- [x] 自動テスト成功
- [x] リファクタリング
- [x] コメントは適切である
- [x] 不要なSleepは設けていない